### PR TITLE
Better errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ JSON5 for Python
 pip install json-five
 ```
 
-This project has just one requirement: the [`sly`](https://github.com/dabeaz/sly) package.
+This project requires Python 3.6 or newer.
 
 ## Usage
 
@@ -34,48 +34,15 @@ comment that can span lines /*
 
 See also the [full documentation](https://json-five.readthedocs.io/en/latest/)
 
-## Project goals
+## Key features
 
-- support a similar interface to the `json` module with support for JSON5 sources
-- support round-trip preservation of comments
+- Supports the JSON5 spec
+- Supports similar interfaces to stdlib `json` module
+- Supports round-trip preservation of comments
+- Tries to find _all_ syntax errors at once (instead of raising on the first error encountered)
 
-## Status/milestones
 
-This project is in very early stages of development. The following are some 
-milestones that hopefully will be able to be marked as done as development progresses.
+## Status
 
-- [x] parse json5 to Python (ignoring comments)
-  - [x] line comments
-  - [x] block comments
-  - [x] numeric literals
-  - [x] trailing commas for arrays and objects
-  - [x] line continuations
-  - [x] ecma identifiers as object keys
-  - [x] leading plus for numbers
-  - [x] single quoted strings
-  - [x] escape characters in strings
-- [x] dump python to JSON (no comment support)
-  - [x] indent style (that matches `json`)
-  - [ ] style options (quotes, trailing commas, etc)
-  - [ ] helper classes for dumping types as other literals (hexadecimal numbers, identifiers, etc)
-  - [x] load/loads to support similar options to `json` (e.g. `object_hook`, `parse_x`, etc)
-  - [ ] dump/dumps to support similar options to `json` module (e.g. hooks, `ensure_ascii`, etc)
-  - [ ] string escapes according to quote style
-- [x] support manipulation of json model (e.g. to add/edit comments)
-- [x] dump json model with comments
-- [x] preserve comments when loading json5 (round-trip support)
-- [ ] Transparent model modification with Python datatype-like objects with methods for modifying comments
-
-...
-
-- [ ] Optimize with a C/Cython version
-
-## How fast is it?
-
-It's nowhere close to the C-optimized `json` stdlib module. We may get closer to that 
-benchmark if/when we rewrite parts with Cython.
-
-In my own limited testing, as of v0.0.2, this module is about 10-450x slower than the stdlib C-optimized `json` 
-and about 10-50x slower than the stdlib pure python version of `json`.
-
-I expect this to slow down marginally when round-trip comment preservation is implemented.
+This project is still in early stages of development. Check the [issues](https://github.com/spyoungtech/json-five/issues) 
+page to see known bugs and unimplemented features.

--- a/json5/__init__.py
+++ b/json5/__init__.py
@@ -1,2 +1,3 @@
 from .loader import loads, load
 from .dumper import dumps, dump
+from .utils import JSON5DecodeError

--- a/json5/parser.py
+++ b/json5/parser.py
@@ -214,6 +214,9 @@ class JSONParser(Parser):
     def double_quoted_string(self, p):
         raw_value = p[0]
         contents = raw_value[1:-1]
+        if re.search(r'(?<!\\)([\u000D\u2028\u2029]|(?<!\r)\n)', contents):
+            errmsg = f"Illegal line terminator without continuation in string at line {p.lineno}"
+            self.errors.append(JSON5DecodeError(errmsg, None))
         contents = re.sub(r'\\(\r\n|[\u000A\u000D\u2028\u2029])', '', contents)
         contents = re.sub(r'\\(.)', replace_escape_literals, contents)
         return DoubleQuotedString(contents, raw_value=raw_value)
@@ -222,6 +225,9 @@ class JSONParser(Parser):
     def single_quoted_string(self, p):
         raw_value = p[0]
         contents = raw_value[1:-1]
+        if re.search(r'(?<!\\)([\u000D\u2028\u2029]|(?<!\r)\n)', contents):
+            errmsg = f"Illegal line terminator without continuation in string at line {p.lineno}"
+            self.errors.append(JSON5DecodeError(errmsg, None))
         contents = re.sub(r'\\(\r\n|[\u000A\u000D\u2028\u2029])', '', contents)
         contents = re.sub(r'\\(.)', replace_escape_literals, contents)
         return SingleQuotedString(contents, raw_value=raw_value)

--- a/json5/parser.py
+++ b/json5/parser.py
@@ -10,12 +10,10 @@ from json5.utils import JSON5DecodeError
 
 
 class QuietSlyLogger(SlyLogger):
-    def debug(self, *args, **kwargs):
-        return
-    info = debug
-
     def warning(self, *args, **kwargs):
         return
+    debug = warning
+    info = warning
 
 
 ESCAPE_SEQUENCES = {

--- a/json5/parser.py
+++ b/json5/parser.py
@@ -215,8 +215,8 @@ class JSONParser(Parser):
         raw_value = p[0]
         contents = raw_value[1:-1]
         if re.search(r'(?<!\\)([\u000D\u2028\u2029]|(?<!\r)\n)', contents):
-            errmsg = f"Illegal line terminator without continuation in string at line {p.lineno}"
-            self.errors.append(JSON5DecodeError(errmsg, None))
+            errmsg = f"Illegal line terminator without continuation"
+            self.errors.append(JSON5DecodeError(errmsg, p._slice[0]))
         contents = re.sub(r'\\(\r\n|[\u000A\u000D\u2028\u2029])', '', contents)
         contents = re.sub(r'\\(.)', replace_escape_literals, contents)
         return DoubleQuotedString(contents, raw_value=raw_value)
@@ -226,8 +226,8 @@ class JSONParser(Parser):
         raw_value = p[0]
         contents = raw_value[1:-1]
         if re.search(r'(?<!\\)([\u000D\u2028\u2029]|(?<!\r)\n)', contents):
-            errmsg = f"Illegal line terminator without continuation in string at line {p.lineno}"
-            self.errors.append(JSON5DecodeError(errmsg, None))
+            errmsg = f"Illegal line terminator without continuation"
+            self.errors.append(JSON5DecodeError(errmsg, p._slice[0]))
         contents = re.sub(r'\\(\r\n|[\u000A\u000D\u2028\u2029])', '', contents)
         contents = re.sub(r'\\(.)', replace_escape_literals, contents)
         return SingleQuotedString(contents, raw_value=raw_value)
@@ -290,9 +290,7 @@ class JSONParser(Parser):
     'IN',
     'TRY',)
     def identifier(self, p):
-        err = JSON5DecodeError(f"Illegal name at line {p.lineno}: {p[0]} is a reserved keyword and may not be used", None)
-        err.lineno = p.lineno
-        err.index = p.index
+        err = JSON5DecodeError(f"Illegal name ({p[0]}) is a reserved keyword and may not be used", p._slice[0])
         self.errors.append(err)
         return Identifier(name=p[0])
 

--- a/json5/tokenizer.py
+++ b/json5/tokenizer.py
@@ -1,7 +1,7 @@
 import re
 import sys
 from sly import Lexer
-
+from json5.utils import JSON5DecodeError
 import logging
 
 logger = logging.getLogger(__name__)
@@ -96,6 +96,8 @@ class JSONLexer(Lexer):
     NAME['in'] = IN
     NAME['try'] = TRY
 
+    def error(self, t):
+        raise JSON5DecodeError(f'Illegal character {t.value[0]!r} at index {self.index}', None)
 
 def tokenize(text):
     lexer = JSONLexer()

--- a/json5/tokenizer.py
+++ b/json5/tokenizer.py
@@ -1,12 +1,28 @@
 import re
 import sys
 from sly import Lexer
+from sly.lex import Token
 from json5.utils import JSON5DecodeError
 import logging
 
 logger = logging.getLogger(__name__)
 # logger.addHandler(logging.StreamHandler(stream=sys.stderr))
 # logger.setLevel(level=logging.DEBUG)
+class JSON5Token(Token):
+    '''
+    Representation of a single token.
+    '''
+    def __init__(self, tok, doc):
+        self.type = tok.type
+        self.value = tok.value
+        self.lineno = tok.lineno
+        self.index = tok.index
+        self.doc = doc
+    __slots__ = ('type', 'value', 'lineno', 'index', 'doc')
+
+    def __repr__(self):
+        return f'JSON5Token(type={self.type!r}, value={self.value!r}, lineno={self.lineno}, index={self.index})'
+
 
 class JSONLexer(Lexer):
     reflags = re.DOTALL
@@ -30,6 +46,11 @@ class JSONLexer(Lexer):
               INFINITY, NAN, EXPONENT,
               HEXADECIMAL
               }
+
+    def tokenize(self, text, *args, **kwargs):
+        for tok in super().tokenize(text, *args, **kwargs):
+            tok = JSON5Token(tok, text)
+            yield tok
 
     LBRACE = r'{'
     RBRACE = r'}'

--- a/json5/utils.py
+++ b/json5/utils.py
@@ -1,5 +1,5 @@
 from functools import singledispatch, update_wrapper
-
+from json import JSONDecodeError
 try:
     from functools import singledispatchmethod
 except ImportError:
@@ -12,3 +12,21 @@ except ImportError:
         wrapper.register = dispatcher.register
         update_wrapper(wrapper, func)
         return wrapper
+
+
+class JSON5DecodeError(JSONDecodeError):
+    def __init__(self, msg, token):
+        lineno = getattr(token, 'lineno', 0)
+        index = getattr(token, 'index', 0)
+        if token:
+            errmsg = f'{msg}: at line {lineno} index {index} token={token.type}'
+        else:
+            errmsg = msg
+        ValueError.__init__(self, errmsg)
+        self.msg = msg
+        self.lineno = lineno
+        self.index = index
+        self.token = token
+
+    def __reduce__(self):
+        return self.__class__, (self.msg, self.token)

--- a/json5/utils.py
+++ b/json5/utils.py
@@ -18,15 +18,18 @@ class JSON5DecodeError(JSONDecodeError):
     def __init__(self, msg, token):
         lineno = getattr(token, 'lineno', 0)
         index = getattr(token, 'index', 0)
-        if token:
-            errmsg = f'{msg}: at line {lineno} index {index} token={token.type}'
-        else:
-            errmsg = msg
-        ValueError.__init__(self, errmsg)
-        self.msg = msg
-        self.lineno = lineno
-        self.index = index
+        doc = getattr(token, 'doc', None)
         self.token = token
+        self.index = index
+        if token and doc:
+            errmsg = f'{msg} in or near token {token.type} at'
+            super().__init__(errmsg, doc, index)
+        else:
+            ValueError.__init__(self, msg)
+            self.msg = msg
+            self.lineno = lineno
 
     def __reduce__(self):
         return self.__class__, (self.msg, self.token)
+
+

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -3,6 +3,8 @@ from json5.dumper import DefaultDumper, ModelDumper, modelize
 from json5.model import LineComment
 import pytest
 
+from json5.utils import JSON5DecodeError
+
 
 def test_loading_comment_raises_runtime_error_default_loader():
     model = LineComment('// foo')
@@ -20,7 +22,7 @@ def test_loading_unknown_node_raises_error():
 
 def test_reserved_keywords_raise_error():
     json_string = """{break: "not good!"}"""
-    with pytest.raises(SyntaxError):
+    with pytest.raises(JSON5DecodeError):
         loads(json_string)
 
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -61,3 +61,9 @@ def test_model_dumper_raises_error_for_unknown_node():
     with pytest.raises(NotImplementedError):
         ModelDumper().dump(f)
 
+def test_multiple_errors_all_surface_at_once():
+    json_string = """[\n"foo",\n"bar"\n"baz",\n"bacon"\n"eggs"]"""
+    # 2 errors due to missing comma  ^                ^
+    with pytest.raises(JSON5DecodeError) as exc_info:
+        loads(json_string)
+    assert str(exc_info.value).count('Syntax Error') == 2

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -67,3 +67,23 @@ def test_multiple_errors_all_surface_at_once():
     with pytest.raises(JSON5DecodeError) as exc_info:
         loads(json_string)
     assert str(exc_info.value).count('Syntax Error') == 2
+
+
+def test_linebreak_without_continuation_fails():
+    json_string = """'Hello \nworld!'"""
+    with pytest.raises(JSON5DecodeError) as exc_info:
+        loads(json_string)
+    assert "Illegal" in str(exc_info.value)
+
+
+def test_linebreak_without_continuation_fails_double():
+    json_string = '''"Hello \nworld!"'''
+    with pytest.raises(JSON5DecodeError) as exc_info:
+        loads(json_string)
+    assert "Illegal" in str(exc_info.value)
+
+
+def test_empty_input_raises_error():
+    with pytest.raises(JSON5DecodeError) as exc_info:
+        loads("")
+    assert "unexpected EOF" in str(exc_info.value)

--- a/tests/test_json5_load.py
+++ b/tests/test_json5_load.py
@@ -5,6 +5,8 @@ from json5.loader import loads, JsonIdentifier, load
 from sly.lex import LexError
 from io import StringIO
 
+from json5.utils import JSON5DecodeError
+
 
 def test_object_string_key_value_pair():
     json_string = """{"foo":"bar"}"""
@@ -134,10 +136,10 @@ def test_line_continuations_alternate_terminators(terminator):
 
 def test_linebreak_without_continuation_fails():
     json_string = """'Hello 
-world!"""
-    with pytest.raises(LexError) as exc_info:
+world!'"""
+    with pytest.raises(JSON5DecodeError) as exc_info:
         loads(json_string)
-    assert "Illegal character" in str(exc_info.value)
+    assert "Illegal" in str(exc_info.value)
 
 
 def test_number_literals_inf_nan():

--- a/tests/test_json5_load.py
+++ b/tests/test_json5_load.py
@@ -134,14 +134,6 @@ def test_line_continuations_alternate_terminators(terminator):
     assert loads(json_string) == "Hello world!"
 
 
-def test_linebreak_without_continuation_fails():
-    json_string = """'Hello 
-world!'"""
-    with pytest.raises(JSON5DecodeError) as exc_info:
-        loads(json_string)
-    assert "Illegal" in str(exc_info.value)
-
-
 def test_number_literals_inf_nan():
     json_string = """{
     "positiveInfinity": Infinity,


### PR DESCRIPTION
A few changes in this PR:

- Introduces the `JSON5DecodeError` class for parsing errors
- Error messages now include the token type, line number, column number, and index.
- A fix for handling line continuations (previously illegal line terminators in strings would parse successfully)

