### PR TITLE
add better error handling for EOF and line continuations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
 
 install:
   - pip install sly regex coverage coveralls
-  - git clone https://github.com/json5/json5-tests.git
+  - git clone https://github.com/spyoungtech/json5-tests.git
 
 script:
   - coverage run -m pytest tests

--- a/tests/test_json5_official_tests.py
+++ b/tests/test_json5_official_tests.py
@@ -2,6 +2,7 @@ from json5 import loads, load, JSON5DecodeError, dumps
 from json5.loader import ModelLoader
 from json5.dumper import ModelDumper
 import os
+import re
 import pytest
 from io import open
 
@@ -40,3 +41,39 @@ def test_official_error_specs(input_file, expected):
         return
     with pytest.raises(JSON5DecodeError) as exc_info:
         load(open(input_file, encoding='utf-8'))
+
+@pytest.mark.parametrize(('input_file', 'expected'), error_specs)
+def test_official_error_specs(input_file, expected):
+    if not os.path.exists(tests_path):
+        pytest.mark.skip("Tests repo was not present in expected location. Skipping.")
+        return
+    if os.path.exists(expected):
+        errorspec = load(open(expected, encoding='utf-8'))
+    else:
+        pytest.mark.skip("No error spec")
+        return
+
+    with pytest.raises(JSON5DecodeError) as exc_info:
+        load(open(input_file, encoding='utf-8'))
+
+    at = errorspec['at']
+    lineno = errorspec['lineNumber']
+    col = errorspec['columnNumber']
+    msg = errorspec['message']
+    exc_message = str(exc_info.value)
+    exc_lineno_match = re.search('line (\d+)', exc_message)
+    if exc_lineno_match:
+        exc_lineno = int(exc_lineno_match.groups()[0])
+    else:
+        exc_lineno = None
+    exc_col_match = re.search('column (\d+)', exc_message)
+    if exc_col_match:
+        exc_col = int(exc_col_match.groups()[0])
+    else:
+        exc_col = None
+    exc_index_match = re.search('char (\d+)', exc_message)
+    if exc_index_match:
+        exc_index = int(exc_index_match.groups()[0])
+    else:
+        exc_index = None
+    assert (lineno, col, at-1) == (exc_lineno, exc_col, exc_index)


### PR DESCRIPTION
Adds better error handling for EOF and line continuations. Specifically, illegal line continuations will be specified by line/col/index in addition to the previous message that indicates the line/col/index where the string starts.