### PR TITLE
Add handling for unterminated strings

### DIFF
--- a/json5/model.py
+++ b/json5/model.py
@@ -164,8 +164,8 @@ class UnaryOp(Value):
         super().__init__(op=op, value=value)
 
 class TrailingComma(Node):
-    ...
-
+    def __init__(self, tok):
+        super().__init__(tok=tok)
 
 class Comment(Node):
     def __init__(self, value):

--- a/json5/parser.py
+++ b/json5/parser.py
@@ -369,7 +369,7 @@ class JSONParser(Parser):
                 additional_errors = '\n\t'.join(err.args[0] for err in self.errors[1:])
                 msg = "There were multiple errors parsing the JSON5 document.\n" \
                       "The primary error was: \n\t{}\n" \
-                      "Additionally, the following errors were also detected:\n\t {}"
+                      "Additionally, the following errors were also detected:\n\t{}"
                 msg = msg.format(primary_error.args[0], additional_errors)
                 err = JSON5DecodeError(msg, None)
                 err.lineno = primary_error.lineno

--- a/json5/parser.py
+++ b/json5/parser.py
@@ -333,6 +333,15 @@ class JSONParser(Parser):
         node = p[0]
         return node
 
+    @_('UNTERMINATED_SINGLE_QUOTE_STRING',
+       'UNTERMINATED_DOUBLE_QUOTE_STRING')
+    def string(self, p):
+        self.error(p._slice[0])
+        raw = p[0]
+        if raw.startswith('"'):
+            return DoubleQuotedString(raw[1:], raw_value=raw)
+        return SingleQuotedString(raw[1:], raw_value=raw)
+
     def error(self, token):
         if token:
             self.errors.append(JSON5DecodeError('Syntax Error', token))

--- a/json5/tokenizer.py
+++ b/json5/tokenizer.py
@@ -30,6 +30,8 @@ class JSONLexer(Lexer):
     tokens = {LBRACE, RBRACE,
               LBRACKET, RBRACKET,
               DOUBLE_QUOTE_STRING, SINGLE_QUOTE_STRING,
+              UNTERMINATED_DOUBLE_QUOTE_STRING,
+              UNTERMINATED_SINGLE_QUOTE_STRING,
               NAME,
               COMMA,
               BLOCK_COMMENT,
@@ -86,6 +88,9 @@ class JSONLexer(Lexer):
     NAME['null'] = NULL
     NAME['Infinity'] = INFINITY
     NAME['NaN'] = NAN
+
+    UNTERMINATED_DOUBLE_QUOTE_STRING = r'"(?:[^"\\]|\\.)*'
+    UNTERMINATED_SINGLE_QUOTE_STRING = r"'(?:[^'\\]|\\.)*"
 
     def error(self, t):
         raise JSON5DecodeError(f'Illegal character {t.value[0]!r} at index {self.index}', None)

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -150,3 +150,10 @@ def test_malformed_octals_result_in_additional_error():
     with pytest.raises(JSON5DecodeError) as exc_info:
         loads(json_string)
     assert "Invalid octal format" in str(exc_info.value)
+
+@pytest.mark.parametrize('json_string', ['{foo: "bar}', "{foo: 'bar}"])
+def test_unterminated_string(json_string):
+    with pytest.raises(JSON5DecodeError) as exc_info:
+        loads(json_string)
+    assert "UNTERMINATED" in str(exc_info.value)
+    assert "7" in str(exc_info.value)  # The index where the underminated string begins

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -157,3 +157,14 @@ def test_unterminated_string(json_string):
         loads(json_string)
     assert "UNTERMINATED" in str(exc_info.value)
     assert "7" in str(exc_info.value)  # The index where the underminated string begins
+
+
+def test_array_multiple_trailing_commas_raises_error():
+    with pytest.raises(JSON5DecodeError) as exc_info:
+        loads('["foo",,]')
+    assert "multiple trailing commas" in str(exc_info.value)
+
+def test_object_multiple_trailing_commas_raises_error():
+    with pytest.raises(JSON5DecodeError) as exc_info:
+        loads('{foo: "bar",,}')
+    assert "multiple trailing commas" in str(exc_info.value)


### PR DESCRIPTION
This PR introduces two new tokens for unterminated strings.

Without these tokens, an unterminated string will result in a confusing error message of "Illegal character '"' ..."

Additionally, this would stop parsing/tokenizing altogether and swallow any errors it had already encountered. By eliminating the tokenizing error (illegal char) unterminated strings can be reported alongside other errors with better error reports.

Before:

```py
>>> json5.loads("[0o123, 'foo]") 
[tb omitted]
JSON5DecodeError: Illegal character "'" at index 8
```
Notice that the octal (which are illegal) goes completely unnoticed until the unterminated string is fixed.

After:
```py
>>> json5.loads("[0o123, 'foo]") 
[tb omitted]
JSON5DecodeError: There were multiple errors parsing the JSON5 document.
The primary error was:
        Invalid integer literal. Octals are not allowed in or near token OCTAL at: line 1 column 2 (char 1)
Additionally, the following errors were also detected:
        Syntax Error in or near token UNTERMINATED_SINGLE_QUOTE_STRING at: line 1 column 9 (char 8)
        Expecting value. Unexpected EOF at: line 1 column 14 (char 13)
```