### PR TITLE
fix multiple trailing commas; informative errors

### DIFF
--- a/json5/model.py
+++ b/json5/model.py
@@ -39,38 +39,38 @@ class Key(Node):
 
 
 class JSONObject(Value):
-    def __init__(self, *key_value_pairs, trailing_comma=None, leading_wsc=None):
+    def __init__(self, *key_value_pairs, trailing_comma=None, leading_wsc=None, tok=None):
         key_value_pairs = list(key_value_pairs)
         for kvp in key_value_pairs:
             assert isinstance(kvp, KeyValuePair), f"Expected key value pair, got {type(kvp)}"
         assert leading_wsc is None or all(isinstance(item, str) or isinstance(item, Comment) for item in leading_wsc)
-        super().__init__(key_value_pairs=key_value_pairs, trailing_comma=trailing_comma, leading_wsc=leading_wsc or [])
+        super().__init__(key_value_pairs=key_value_pairs, trailing_comma=trailing_comma, leading_wsc=leading_wsc or [], tok=tok)
 
 
 class JSONArray(Value):
-    def __init__(self, *values, trailing_comma=None, leading_wsc=None):
+    def __init__(self, *values, trailing_comma=None, leading_wsc=None, tok=None):
         values = list(values)
         for value in values:
             assert isinstance(value, Value), f"Was expecting object with type Value. Got {type(value)}"
         assert leading_wsc is None or all(isinstance(item, str) or isinstance(item, Comment) for item in leading_wsc)
-        super().__init__(values=values, trailing_comma=trailing_comma, leading_wsc=leading_wsc or [])
+        super().__init__(values=values, trailing_comma=trailing_comma, leading_wsc=leading_wsc or [], tok=tok)
 
 
 class KeyValuePair(Node):
-    def __init__(self, key, value):
+    def __init__(self, key, value, tok=None):
         assert isinstance(key, Key)
         assert isinstance(value, Value)
-        super().__init__(key=key, value=value)
+        super().__init__(key=key, value=value, tok=tok)
 
 
 class Identifier(Key):
-    def __init__(self, name, raw_value=None):
+    def __init__(self, name, raw_value=None, tok=None):
         assert isinstance(name, str)
         if raw_value is None:
             raw_value = name
         assert isinstance(raw_value, str)
         assert len(name) > 0
-        super().__init__(name=name, raw_value=raw_value)
+        super().__init__(name=name, raw_value=raw_value, tok=tok)
 
     def __hash__(self):
         return hash(self.name)
@@ -84,7 +84,7 @@ class Number(Value):
 
 
 class Integer(Number):
-    def __init__(self, raw_value, is_hex=False, is_octal=False):
+    def __init__(self, raw_value, is_hex=False, is_octal=False, tok=None):
         assert isinstance(raw_value, str)
         if is_hex and is_octal:
             raise ValueError("is_hex and is_octal are mutually exclusive")
@@ -97,19 +97,19 @@ class Integer(Number):
                 value = int(raw_value.replace('0', '0o', 1), 8)
         else:
             value = int(raw_value)
-        super().__init__(raw_value=raw_value, value=value, is_hex=is_hex, is_octal=is_octal)
+        super().__init__(raw_value=raw_value, value=value, is_hex=is_hex, is_octal=is_octal, tok=tok)
 
 
 class Float(Number):
-    def __init__(self, raw_value, exp_notation=None):
+    def __init__(self, raw_value, exp_notation=None, tok=None):
         value = float(raw_value)
         assert exp_notation is None or exp_notation in ('e', 'E')
-        super().__init__(raw_value=raw_value, value=value, exp_notation=exp_notation)
+        super().__init__(raw_value=raw_value, value=value, exp_notation=exp_notation, tok=tok)
 
 
 class Infinity(Number):
-    def __init__(self, negative=False):
-        super().__init__(negative=negative)
+    def __init__(self, negative=False, tok=None):
+        super().__init__(negative=negative, tok=tok)
 
     @property
     def value(self):
@@ -120,8 +120,8 @@ class Infinity(Number):
         return '-Infinity' if self.negative else 'Infinity'
 
 class NaN(Number):
-    def __init__(self):
-        super().__init__(value=math.nan)
+    def __init__(self, tok=None):
+        super().__init__(value=math.nan, tok=tok)
 
     @property
     def const(self):
@@ -131,46 +131,46 @@ class String(Value, Key):
     ...
 
 class DoubleQuotedString(String):
-    def __init__(self, characters, raw_value):
+    def __init__(self, characters, raw_value, tok=None):
         assert isinstance(raw_value, str)
         characters = characters
         assert isinstance(characters, str)
-        super().__init__(characters=characters, raw_value=raw_value)
+        super().__init__(characters=characters, raw_value=raw_value, tok=tok)
 
 
 class SingleQuotedString(String):
-    def __init__(self, characters, raw_value):
+    def __init__(self, characters, raw_value, tok=None):
         assert isinstance(raw_value, str)
         characters = characters
         assert isinstance(characters, str)
-        super().__init__(characters=characters, raw_value=raw_value)
+        super().__init__(characters=characters, raw_value=raw_value, tok=tok)
 
 
 class BooleanLiteral(Value):
-    def __init__(self, value):
+    def __init__(self, value, tok=None):
         assert value in (True, False)
-        super().__init__(value=value)
+        super().__init__(value=value, tok=tok)
 
 
 class NullLiteral(Value):
-    def __init__(self):
-        super().__init__(value=None)
+    def __init__(self, tok=None):
+        super().__init__(value=None, tok=tok)
 
 
 class UnaryOp(Value):
-    def __init__(self, op, value):
+    def __init__(self, op, value, tok=None):
         assert op in ('-', '+')
         assert isinstance(value, Number)
-        super().__init__(op=op, value=value)
+        super().__init__(op=op, value=value, tok=tok)
 
 class TrailingComma(Node):
-    def __init__(self, tok):
+    def __init__(self, tok=None):
         super().__init__(tok=tok)
 
 class Comment(Node):
-    def __init__(self, value):
+    def __init__(self, value, tok=None):
         assert isinstance(value, str), f"Expected str got {type(value)}"
-        super().__init__(value=value)
+        super().__init__(value=value, tok=tok)
 
 
 class LineComment(Comment):

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -168,3 +168,48 @@ def test_object_multiple_trailing_commas_raises_error():
     with pytest.raises(JSON5DecodeError) as exc_info:
         loads('{foo: "bar",,}')
     assert "multiple trailing commas" in str(exc_info.value)
+
+def test_expecting_rbracket():
+    json_string = """[true, false"""
+    with pytest.raises(JSON5DecodeError) as exc_info:
+        loads(json_string)
+
+
+
+
+def test_array_expecting_value_or_bracket():
+    json_string = '['
+    with pytest.raises(JSON5DecodeError) as exc_info:
+        loads(json_string)
+    assert 'RBRACKET or value' in str(exc_info.value)
+
+def test_array_expecting_comma_or_bracket():
+    json_string = '[true'
+    with pytest.raises(JSON5DecodeError) as exc_info:
+        loads(json_string)
+    assert "RBRACKET or COMMA" in str(exc_info.value)
+
+def test_array_expecting_value_or_bracket_trailing_comma():
+    json_string = '[true,'
+    with pytest.raises(JSON5DecodeError) as exc_info:
+        loads(json_string)
+
+    assert 'RBRACKET or value' in str(exc_info.value)
+
+def test_object_expecting_value_or_brace():
+    json_string = '{'
+    with pytest.raises(JSON5DecodeError) as exc_info:
+        loads(json_string)
+    assert 'RBRACE or key' in str(exc_info.value)
+
+def test_object_expecting_comma_or_brace():
+    json_string = '{foo: true'
+    with pytest.raises(JSON5DecodeError) as exc_info:
+        loads(json_string)
+    assert "COMMA or RBRACE" in str(exc_info.value)
+
+def test_object_expecting_key_or_brace_trailing_comma():
+    json_string = '{foo: true,'
+    with pytest.raises(JSON5DecodeError) as exc_info:
+        loads(json_string)
+    assert 'RBRACE or key' in str(exc_info.value)

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -1,0 +1,19 @@
+import pytest
+from json5 import loads, JSON5DecodeError
+
+
+## These tests used to cause the program to hang indefinitely
+def test_no_hang():
+    json_string = '{"foo": ["foo", [0o11]}, ["baz"]]'
+    with pytest.raises(JSON5DecodeError) as exc_info:
+        loads(json_string)
+
+def test_no_hang2():
+    json_string = '[{foo:]}'
+    with pytest.raises(JSON5DecodeError) as exc_info:
+        loads(json_string)
+
+def test_no_hang3():
+    json_string = '[true, {foo:]false}'
+    with pytest.raises(JSON5DecodeError) as exc_info:
+        loads(json_string)


### PR DESCRIPTION
Includes a fix for identifying the correct token for multiple trailing comma errors

Also introducing informative errors that follow the parsing process more closely. For example

```python
>>> json5.loads('[')
JSON5DecodeError: Expecting value. Unexpected EOF at: line 1 column 2 (char 1). Was expecting RBRACKET or value
>>> json5.loads('[true')
JSON5DecodeError: Expecting value. Unexpected EOF at: line 1 column 6 (char 5). Was expecting RBRACKET or COMMA
>>> json5.loads('[true,')
JSON5DecodeError: Expecting value. Unexpected EOF at: line 1 column 7 (char 6). Was expecting RBRACKET or value
```

Additionally, the number of errors per document is limited to 6: the primary error and 5 secondary errors. All other errors are truncated. This is for a few reasons: (1) most often, subsequent errors are the result of preceding errors and (2) it prevents the possibility of a single error at the top of a large JSON file from flooding the screen with erroneous errors.

For instance:

```python
>>> json5.loads('[{foo: 123} /* <--- one little mistake */{{{{{{{{{{}}}}}}}}}}' )
JSON5DecodeError: There were multiple errors parsing the JSON5 document.
The primary error was:
        Syntax Error. Was expecting RBRACKET or COMMA in or near token LBRACE at: line 1 column 42 (char 41)
Additionally, the following errors were also detected:
        Syntax Error. Was expecting RBRACKET or COMMA in or near token LBRACE at: line 1 column 43 (char 42)
        Syntax Error. Was expecting RBRACKET or COMMA in or near token LBRACE at: line 1 column 44 (char 43)
        Syntax Error. Was expecting RBRACKET or COMMA in or near token LBRACE at: line 1 column 45 (char 44)
        Syntax Error. Was expecting RBRACKET or COMMA in or near token LBRACE at: line 1 column 46 (char 45)
        Syntax Error. Was expecting RBRACKET or COMMA in or near token LBRACE at: line 1 column 47 (char 46)
        15 additional error(s) truncated
```