### PR TITLE
Add Typing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,13 +14,13 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        python-version: 3.11
 
     - name: build
       shell: bash
       run: |
-        python -m pip install --upgrade wheel setuptools sly regex
-        python setup.py sdist bdist_wheel
+        python -m pip install --upgrade wheel setuptools sly regex build
+        python -m build
 
     - name: Release PyPI
       shell: bash

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -2,6 +2,10 @@ on: [ push, pull_request ]
 
 jobs:
   build:
+    strategy:
+      fail-fast: false
+      matrix:
+        python_version: ["3.10", "3.9", "3.8", "3.11"]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -9,17 +13,20 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: ${{ matrix.python_version }}
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install sly coverage regex pytest
+          python -m pip install -r requirements-dev.txt
+          python -m pip install .
+          python -m pip install tox
 
       - name: Test with coverage/pytest
+        env:
+          PYTHONUNBUFFERED: "1"
         run: |
-          coverage run -m pytest tests
-
+          tox -e py
       - name: Coveralls
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -21,6 +21,7 @@ jobs:
           python -m pip install -r requirements-dev.txt
           python -m pip install .
           python -m pip install tox
+          git clone https://github.com/json5/json5-tests.git
 
       - name: Test with coverage/pytest
         env:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,3 +18,29 @@ repos:
             - "-S"
             - "-l"
             - "120"
+
+-   repo: https://github.com/asottile/pyupgrade
+    rev: v3.10.1
+    hooks:
+    -   id: pyupgrade
+        args: ["--py38-plus"]
+
+-   repo: https://github.com/pre-commit/mirrors-mypy
+    rev: 'v1.4.1'
+    hooks:
+    -   id: mypy
+        args:
+            - "--strict"
+            - "--disable-error-code"
+            - "name-defined"
+        exclude: ^(tests/.*|setup.py|docs/.*)
+        additional_dependencies:
+          - types-regex
+
+-   repo: https://github.com/pycqa/flake8
+    rev: '6.0.0'  # pick a git hash / tag to point to
+    hooks:
+    -   id: flake8
+        args:
+          - "--ignore"
+          - "E501,E704,E301,W503,F405,F811,F821,F403,"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,3 +5,16 @@ repos:
     -   id: check-yaml
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
+-   repo: https://github.com/asottile/reorder-python-imports
+    rev: v3.10.0
+    hooks:
+    -   id: reorder-python-imports
+
+-   repo: https://github.com/psf/black
+    rev: '23.7.0'
+    hooks:
+    -   id: black
+        args:
+            - "-S"
+            - "-l"
+            - "120"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,9 +3,7 @@
 # This file only contains a selection of the most common options. For a full
 # list see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
-
 # -- Path setup --------------------------------------------------------------
-
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
@@ -13,8 +11,6 @@
 # import os
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
-
-
 # -- Project information -----------------------------------------------------
 
 project = 'json-five'
@@ -30,8 +26,7 @@ release = '0.1.0'
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = [
-]
+extensions = []
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/json5/__init__.py
+++ b/json5/__init__.py
@@ -1,3 +1,5 @@
-from .loader import loads, load
-from .dumper import dumps, dump
+from .dumper import dump
+from .dumper import dumps
+from .loader import load
+from .loader import loads
 from .utils import JSON5DecodeError

--- a/json5/__init__.py
+++ b/json5/__init__.py
@@ -3,3 +3,5 @@ from .dumper import dumps
 from .loader import load
 from .loader import loads
 from .utils import JSON5DecodeError
+
+__all__ = ['dump', 'dumps', 'load', 'loads', 'JSON5DecodeError']

--- a/json5/dumper.py
+++ b/json5/dumper.py
@@ -1,21 +1,26 @@
 from __future__ import annotations
-from typing import Dict, Any, Optional, List, Union
+
+import io
+import json
+import math
 import typing
 from abc import abstractmethod
-import math
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Union
+
 from .loader import JsonIdentifier
 from .utils import singledispatchmethod
 from json5.model import *
-from collections import UserDict
-import json
-import io
+
 
 class Environment:
     def __init__(self) -> None:
         self.outfile: typing.TextIO = io.StringIO()
         self.indent_level: int = 0
         self.indent: int = 0
-
 
     def write(self, s: str, indent: Optional[int] = None) -> None:
         if indent is None:
@@ -40,6 +45,7 @@ def dumps(obj: Any, dumper: Optional[BaseDumper] = None, indent: int = 0) -> str
     ret: str = dumper.env.outfile.read()
     return ret
 
+
 class BaseDumper:
     def __init__(self, env: Optional[Environment] = None):
         if env is None:
@@ -51,10 +57,12 @@ class BaseDumper:
     def dump(self, obj: Any) -> Any:
         return NotImplemented
 
+
 class DefaultDumper(BaseDumper):
     """
     Dump Python objects to a JSON string
     """
+
     @singledispatchmethod
     def dump(self, obj: Any) -> Any:
         raise NotImplementedError(f"Cannot dump node {repr(obj)}")
@@ -88,7 +96,6 @@ class DefaultDumper(BaseDumper):
         else:
             self.env.write('}', indent=0)
 
-
     @to_json(int)
     def int_to_json(self, i: int) -> Any:
         self.env.write(str(i), indent=0)
@@ -100,7 +107,6 @@ class DefaultDumper(BaseDumper):
     @to_json(str)
     def str_to_json(self, s: str) -> Any:
         self.env.write(json.dumps(s), indent=0)
-
 
     @to_json(list)
     def list_to_json(self, l: List[Any]) -> Any:
@@ -124,7 +130,6 @@ class DefaultDumper(BaseDumper):
             self.env.indent_level -= 1
         self.env.write(']')
 
-
     @to_json(float)
     def float_to_json(self, f: float) -> Any:
         if f == math.inf:
@@ -144,10 +149,12 @@ class DefaultDumper(BaseDumper):
     def none_to_json(self, _: Any) -> Any:
         self.env.write('null', indent=0)
 
+
 class ModelDumper:
     """
     Dump a model to a JSON string
     """
+
     def __init__(self, env: Optional[Environment] = None):
         #  any provided environment is ignored
         self.env = Environment()
@@ -301,10 +308,12 @@ class ModelDumper:
         self.env.write('NaN')
         self.process_wsc_after(node)
 
+
 class Modelizer:
     """
     Turn Python objects into a model
     """
+
     @singledispatchmethod
     def modelize(self, obj: Any) -> Node:
         raise NotImplementedError(f"Cannot modelize object of type {type(obj)}")
@@ -336,7 +345,6 @@ class Modelizer:
     @to_model(int)
     def int_to_model(self, i: int) -> Integer:
         return Integer(str(i))
-
 
     @to_model(float)
     def float_to_model(self, f: float) -> Union[Infinity, NaN, Float, UnaryOp]:

--- a/json5/dumper.py
+++ b/json5/dumper.py
@@ -1,3 +1,8 @@
+from __future__ import annotations
+from typing import Dict, Any, Optional, List, Union
+import typing
+from abc import abstractmethod
+import math
 from .loader import JsonIdentifier
 from .utils import singledispatchmethod
 from json5.model import *
@@ -5,15 +10,14 @@ from collections import UserDict
 import json
 import io
 
-class Environment(UserDict):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.outfile = io.StringIO()
-        self.indent_level = 0
-        self.indent = 0
+class Environment:
+    def __init__(self) -> None:
+        self.outfile: typing.TextIO = io.StringIO()
+        self.indent_level: int = 0
+        self.indent: int = 0
 
 
-    def write(self, s, indent=None):
+    def write(self, s: str, indent: Optional[int] = None) -> None:
         if indent is None:
             indent = self.indent_level
         whitespace = ' ' * self.indent * indent
@@ -21,37 +25,44 @@ class Environment(UserDict):
         self.outfile.write(s)
 
 
-def dump(obj, f, **kwargs):
+def dump(obj: Any, f: typing.TextIO, **kwargs: Any) -> int:
     text = dumps(obj, **kwargs)
     return f.write(text)
 
 
-def dumps(obj, dumper=None, indent=0):
+def dumps(obj: Any, dumper: Optional[BaseDumper] = None, indent: int = 0) -> str:
     env = Environment()
     env.indent = indent
     if dumper is None:
         dumper = DefaultDumper(env=env)
     model = dumper.dump(obj)
     dumper.env.outfile.seek(0)
-    return dumper.env.outfile.read()
+    ret: str = dumper.env.outfile.read()
+    return ret
 
-class DefaultDumper:
-    """
-    Dump Python objects to a JSON string
-    """
-    def __init__(self, env=None):
+class BaseDumper:
+    def __init__(self, env: Optional[Environment] = None):
         if env is None:
             env = Environment()
         self.env = env
 
     @singledispatchmethod
-    def dump(self, obj):
+    @abstractmethod
+    def dump(self, obj: Any) -> Any:
+        return NotImplemented
+
+class DefaultDumper(BaseDumper):
+    """
+    Dump Python objects to a JSON string
+    """
+    @singledispatchmethod
+    def dump(self, obj: Any) -> Any:
         raise NotImplementedError(f"Cannot dump node {repr(obj)}")
 
     to_json = dump.register
 
     @to_json(dict)
-    def dict_to_json(self, d):
+    def dict_to_json(self, d: Dict[Any, Any]) -> Any:
         self.env.write('{', indent=0)
         if self.env.indent:
             self.env.write('\n')
@@ -79,20 +90,20 @@ class DefaultDumper:
 
 
     @to_json(int)
-    def int_to_json(self, i):
+    def int_to_json(self, i: int) -> Any:
         self.env.write(str(i), indent=0)
 
     @to_json(JsonIdentifier)
-    def identifier_to_json(self, s):
+    def identifier_to_json(self, s: JsonIdentifier) -> Any:
         self.env.write(s, indent=0)
 
     @to_json(str)
-    def str_to_json(self, s):
+    def str_to_json(self, s: str) -> Any:
         self.env.write(json.dumps(s), indent=0)
 
 
     @to_json(list)
-    def list_to_json(self, l):
+    def list_to_json(self, l: List[Any]) -> Any:
         self.env.write('[', indent=0)
         if self.env.indent:
             self.env.indent_level += 1
@@ -115,7 +126,7 @@ class DefaultDumper:
 
 
     @to_json(float)
-    def float_to_json(self, f):
+    def float_to_json(self, f: float) -> Any:
         if f == math.inf:
             self.env.write('Infinity', indent=0)
         elif f == -math.inf:
@@ -126,22 +137,22 @@ class DefaultDumper:
             self.env.write(str(f), indent=0)
 
     @to_json(bool)
-    def bool_to_json(self, b):
+    def bool_to_json(self, b: bool) -> Any:
         self.env.write(str(b).lower(), indent=0)
 
     @to_json(type(None))
-    def none_to_json(self, _):
+    def none_to_json(self, _: Any) -> Any:
         self.env.write('null', indent=0)
 
 class ModelDumper:
     """
     Dump a model to a JSON string
     """
-    def __init__(self, env=None):
+    def __init__(self, env: Optional[Environment] = None):
         #  any provided environment is ignored
         self.env = Environment()
 
-    def process_wsc_before(self, node):
+    def process_wsc_before(self, node: Node) -> None:
         for wsc in node.wsc_before:
             if isinstance(wsc, Comment):
                 self.dump(wsc)
@@ -150,7 +161,7 @@ class ModelDumper:
             else:
                 raise ValueError(f"Did not expect {type(node)}")
 
-    def process_wsc_after(self, node):
+    def process_wsc_after(self, node: Node) -> None:
         for wsc in node.wsc_after:
             if isinstance(wsc, Comment):
                 self.dump(wsc)
@@ -159,7 +170,7 @@ class ModelDumper:
             else:
                 raise ValueError(f"Did not expect {type(wsc)}")
 
-    def process_leading_wsc(self, node):
+    def process_leading_wsc(self, node: Union[JSONObject, JSONArray]) -> None:
         for wsc in node.leading_wsc:
             if isinstance(wsc, Comment):
                 self.dump(wsc)
@@ -169,19 +180,19 @@ class ModelDumper:
                 raise ValueError(f"Did not expect {type(wsc)}")
 
     @singledispatchmethod
-    def dump(self, node):
+    def dump(self, node: Node) -> Any:
         raise NotImplementedError('foo')
 
     to_json = dump.register
 
     @to_json(JSONText)
-    def json_model_to_json(self, node):
+    def json_model_to_json(self, node: JSONText) -> Any:
         self.process_wsc_before(node)
         self.dump(node.value)
         self.process_wsc_after(node)
 
     @to_json(JSONObject)
-    def json_object_to_json(self, node):
+    def json_object_to_json(self, node: JSONObject) -> Any:
         self.process_wsc_before(node)
         self.env.write('{')
         if node.leading_wsc:
@@ -199,7 +210,7 @@ class ModelDumper:
         self.process_wsc_after(node)
 
     @to_json(JSONArray)
-    def json_array_to_json(self, node):
+    def json_array_to_json(self, node: JSONArray) -> Any:
         self.process_wsc_before(node)
         self.env.write('[')
         if node.leading_wsc:
@@ -214,44 +225,44 @@ class ModelDumper:
         self.process_wsc_after(node)
 
     @to_json(Identifier)
-    def identifier_to_json(self, node):
+    def identifier_to_json(self, node: Identifier) -> Any:
         self.process_wsc_before(node)
         self.env.write(node.raw_value)
         self.process_wsc_after(node)
 
     @to_json(Integer)
-    def integer_to_json(self, node):
+    def integer_to_json(self, node: Integer) -> Any:
         self.process_wsc_before(node)
         self.env.write(node.raw_value)
         self.process_wsc_after(node)
 
     @to_json(Float)
-    def float_to_json(self, node):
+    def float_to_json(self, node: Float) -> Any:
         self.process_wsc_before(node)
         self.env.write(node.raw_value)
         self.process_wsc_after(node)
 
     @to_json(UnaryOp)
-    def unary_to_json(self, node):
+    def unary_to_json(self, node: UnaryOp) -> Any:
         self.process_wsc_before(node)
         self.env.write(node.op)
         self.dump(node.value)
         self.process_wsc_after(node)
 
     @to_json(String)
-    def string_to_json(self, node):
+    def string_to_json(self, node: Union[SingleQuotedString, DoubleQuotedString]) -> Any:
         self.process_wsc_before(node)
         self.env.write(node.raw_value)  # The original value, including any escape sequences or line continuations
         self.process_wsc_after(node)
 
     @to_json(NullLiteral)
-    def null_to_json(self, node):
+    def null_to_json(self, node: NullLiteral) -> Any:
         self.process_wsc_before(node)
         self.env.write('null')
         self.process_wsc_after(node)
 
     @to_json(BooleanLiteral)
-    def boolean_to_json(self, node):
+    def boolean_to_json(self, node: BooleanLiteral) -> Any:
         self.process_wsc_before(node)
         if node.value:
             self.env.write('true')
@@ -260,32 +271,32 @@ class ModelDumper:
         self.process_wsc_after(node)
 
     @to_json(LineComment)
-    def line_comment_to_json(self, node):
+    def line_comment_to_json(self, node: LineComment) -> Any:
         self.process_wsc_before(node)
         self.env.write(node.value)
         self.process_wsc_after(node)
 
     @to_json(BlockComment)
-    def block_comment_to_json(self, node):
+    def block_comment_to_json(self, node: BlockComment) -> Any:
         self.process_wsc_before(node)
         self.env.write(node.value)
         self.process_wsc_after(node)
 
     @to_json(TrailingComma)
-    def trailing_comma_to_json(self, node):
+    def trailing_comma_to_json(self, node: TrailingComma) -> Any:
         self.process_wsc_before(node)
         self.env.write(',')
         self.process_wsc_after(node)
 
     @to_json(Infinity)
-    def infinity_to_json(self, node):
+    def infinity_to_json(self, node: Infinity) -> Any:
         self.process_wsc_before(node)
 
         self.env.write('Infinity')
         self.process_wsc_after(node)
 
     @to_json(NaN)
-    def nan_to_json(self, node):
+    def nan_to_json(self, node: NaN) -> Any:
         self.process_wsc_before(node)
         self.env.write('NaN')
         self.process_wsc_after(node)
@@ -295,40 +306,40 @@ class Modelizer:
     Turn Python objects into a model
     """
     @singledispatchmethod
-    def modelize(self, obj):
+    def modelize(self, obj: Any) -> Node:
         raise NotImplementedError(f"Cannot modelize object of type {type(obj)}")
 
     to_model = modelize.register
 
     @to_model(str)
-    def str_to_model(self, s):
+    def str_to_model(self, s: str) -> Union[SingleQuotedString, DoubleQuotedString]:
         if repr(s).startswith("'"):
             return SingleQuotedString(s, raw_value=repr(s))
         else:
             return DoubleQuotedString(s, raw_value=repr(s))
 
     @to_model(dict)
-    def dict_to_model(self, d):
-        kvps = []
+    def dict_to_model(self, d: Dict[Any, Any]) -> JSONObject:
+        kvps: List[KeyValuePair] = []
         for key, value in d.items():
-            kvp = KeyValuePair(key=self.modelize(key), value=self.modelize(value))
+            kvp = KeyValuePair(key=self.modelize(key), value=self.modelize(value))  # type: ignore[arg-type]
             kvps.append(kvp)
         return JSONObject(*kvps)
 
     @to_model(list)
-    def list_to_model(self, lst):
-        list_values = []
+    def list_to_model(self, lst: List[Any]) -> JSONArray:
+        list_values: List[Value] = []
         for v in lst:
-            list_values.append(self.modelize(v))
+            list_values.append(self.modelize(v))  # type: ignore[arg-type]
         return JSONArray(*list_values)
 
     @to_model(int)
-    def int_to_model(self, i):
+    def int_to_model(self, i: int) -> Integer:
         return Integer(str(i))
 
 
     @to_model(float)
-    def float_to_model(self, f):
+    def float_to_model(self, f: float) -> Union[Infinity, NaN, Float, UnaryOp]:
         if f == math.inf:
             return Infinity()
         elif f == -math.inf:
@@ -339,15 +350,15 @@ class Modelizer:
             return Float(str(f))
 
     @to_model(bool)
-    def bool_to_model(self, b):
+    def bool_to_model(self, b: bool) -> BooleanLiteral:
         return BooleanLiteral(b)
 
     @to_model(type(None))
-    def none_to_model(self, _):
+    def none_to_model(self, _: Any) -> NullLiteral:
         return NullLiteral()
 
 
-def modelize(obj):
+def modelize(obj: Any) -> Node:
     """
 
     :param obj: a python object

--- a/json5/loader.py
+++ b/json5/loader.py
@@ -1,42 +1,48 @@
 from __future__ import annotations
-import types
-
-import sys
-import typing
-from abc import abstractmethod
-from typing import Dict, List, Callable, Literal, Tuple
-from json5.parser import parse_source
-from json5.model import *
-from json5.utils import singledispatchmethod
-from collections import UserString
-
 
 import logging
+import typing
+from abc import abstractmethod
+from typing import Callable
+from typing import Dict
+from typing import List
+from typing import Literal
+from typing import Tuple
+
+from json5.model import *
+from json5.parser import parse_source
+from json5.utils import singledispatchmethod
+
 logger = logging.getLogger(__name__)
 # logger.setLevel(level=logging.DEBUG)
 # logger.addHandler(logging.StreamHandler(stream=sys.stderr))
 
+
 class Environment:
-    def __init__(self,
-                 object_hook: Optional[Callable[[Dict[typing.Any, typing.Any]], typing.Any]] = None,
-                 parse_float: Optional[Callable[[str], typing.Any]] = None,
-                 parse_int: Optional[Callable[[str], typing.Any]] = None,
-                 parse_constant: Optional[Callable[[Literal['-Infinity', 'Infinity', 'NaN']], typing.Any]] = None,
-                 strict: bool = True,
-                 object_pairs_hook: Optional[Callable[[List[Tuple[Union[str, JsonIdentifier], typing.Any]]], typing.Any]] = None,
-                 parse_json5_identifiers: Optional[Callable[[JsonIdentifier], typing.Any]] = None
-                 ):
+    def __init__(
+        self,
+        object_hook: Optional[Callable[[Dict[typing.Any, typing.Any]], typing.Any]] = None,
+        parse_float: Optional[Callable[[str], typing.Any]] = None,
+        parse_int: Optional[Callable[[str], typing.Any]] = None,
+        parse_constant: Optional[Callable[[Literal['-Infinity', 'Infinity', 'NaN']], typing.Any]] = None,
+        strict: bool = True,
+        object_pairs_hook: Optional[Callable[[List[Tuple[Union[str, JsonIdentifier], typing.Any]]], typing.Any]] = None,
+        parse_json5_identifiers: Optional[Callable[[JsonIdentifier], typing.Any]] = None,
+    ):
         self.object_hook: Optional[Callable[[Dict[typing.Any, typing.Any]], typing.Any]] = object_hook
         self.parse_float: Optional[Callable[[str], typing.Any]] = parse_float
         self.parse_int: Optional[Callable[[str], typing.Any]] = parse_int
         self.parse_constant: Optional[Callable[[Literal['-Infinity', 'Infinity', 'NaN']], typing.Any]] = parse_constant
         self.strict: bool = strict
-        self.object_pairs_hook: Optional[Callable[[List[Tuple[Union[str, JsonIdentifier], typing.Any]]], typing.Any]] = object_pairs_hook
+        self.object_pairs_hook: Optional[
+            Callable[[List[Tuple[Union[str, JsonIdentifier], typing.Any]]], typing.Any]
+        ] = object_pairs_hook
         self.parse_json5_identifiers: Optional[Callable[[JsonIdentifier], typing.Any]] = parse_json5_identifiers
 
 
 class JsonIdentifier(str):
     ...
+
 
 def load(f: typing.TextIO, **kwargs: typing.Any) -> typing.Any:
     """
@@ -49,13 +55,27 @@ def load(f: typing.TextIO, **kwargs: typing.Any) -> typing.Any:
     text = f.read()
     return loads(text, **kwargs)
 
+
 @typing.overload
-def loads(s: str, *, loader: None) -> typing.Union[int, float, str, dict[typing.Any, typing.Any], list[typing.Any], None, ]: ...
+def loads(
+    s: str, *, loader: None
+) -> typing.Union[int, float, str, dict[typing.Any, typing.Any], list[typing.Any], None,]:
+    ...
+
+
 @typing.overload
-def loads(s: str, *, loader: DefaultLoader) -> typing.Union[int, float, str, dict[typing.Any, typing.Any], list[typing.Any], None, ]: ...
+def loads(
+    s: str, *, loader: DefaultLoader
+) -> typing.Union[int, float, str, dict[typing.Any, typing.Any], list[typing.Any], None,]:
+    ...
+
+
 @typing.overload
-def loads(s: str, *, loader: typing.Optional[LoaderBase]=None, **kwargs: typing.Any) -> typing.Any: ...
-def loads(s: str, *, loader: typing.Optional[LoaderBase]=None, **kwargs: typing.Any) -> typing.Any:
+def loads(s: str, *, loader: typing.Optional[LoaderBase] = None, **kwargs: typing.Any) -> typing.Any:
+    ...
+
+
+def loads(s: str, *, loader: typing.Optional[LoaderBase] = None, **kwargs: typing.Any) -> typing.Any:
     """
     Take a string of JSON text and deserialize it
 
@@ -75,8 +95,9 @@ def loads(s: str, *, loader: typing.Optional[LoaderBase]=None, **kwargs: typing.
         loader = DefaultLoader(**kwargs)
     return loader.load(model)
 
+
 class LoaderBase:
-    def __init__(self, env: typing.Optional[Environment]=None, **env_kwargs: typing.Any):
+    def __init__(self, env: typing.Optional[Environment] = None, **env_kwargs: typing.Any):
         if env is None:
             env = Environment(**env_kwargs)
         self.env: Environment = env
@@ -85,6 +106,7 @@ class LoaderBase:
     @abstractmethod
     def load(self, node: Node) -> typing.Any:
         return NotImplemented
+
 
 class DefaultLoader(LoaderBase):
     @singledispatchmethod
@@ -112,7 +134,6 @@ class DefaultLoader(LoaderBase):
             return self.env.object_hook(d)
         else:
             return d
-
 
     @to_python(JSONArray)
     def json_array_to_python(self, node: JSONArray) -> list[typing.Any]:
@@ -169,9 +190,8 @@ class DefaultLoader(LoaderBase):
     @to_python(String)
     def string_to_python(self, node: Union[DoubleQuotedString, SingleQuotedString]) -> str:
         logger.debug('string_to_python evaluating node %r', node)
-        ret : str = node.characters
+        ret: str = node.characters
         return ret
-
 
     @to_python(NullLiteral)
     def null_to_python(self, node: NullLiteral) -> None:

--- a/json5/loader.py
+++ b/json5/loader.py
@@ -142,7 +142,7 @@ class DefaultLoader(LoaderBase):
         return node.value
 
     @to_python(Integer)
-    def integer_to_python(self, node) -> typing.Any:
+    def integer_to_python(self, node: Integer) -> typing.Any:
         if self.env.parse_int:
             return self.env.parse_int(node.raw_value)
         else:
@@ -156,7 +156,7 @@ class DefaultLoader(LoaderBase):
             return node.value
 
     @to_python(UnaryOp)
-    def unary_to_python(self, node) -> typing.Any:
+    def unary_to_python(self, node: UnaryOp) -> typing.Any:
         logger.debug('unary_to_python evaluating node %r', node)
         if isinstance(node.value, Infinity):
             return self.load(node.value)
@@ -167,23 +167,24 @@ class DefaultLoader(LoaderBase):
             return value
 
     @to_python(String)
-    def string_to_python(self, node):
+    def string_to_python(self, node: Union[DoubleQuotedString, SingleQuotedString]) -> str:
         logger.debug('string_to_python evaluating node %r', node)
-        return node.characters
+        ret : str = node.characters
+        return ret
 
 
     @to_python(NullLiteral)
-    def null_to_python(self, node):
+    def null_to_python(self, node: NullLiteral) -> None:
         logger.debug('null_to_python evaluating node %r', node)
         return None
 
     @to_python(BooleanLiteral)
-    def boolean_to_python(self, node):
+    def boolean_to_python(self, node: BooleanLiteral) -> bool:
         logger.debug('boolean_to_python evaluating node %r', node)
         return node.value
 
     @to_python(Comment)
-    def comment_or_whitespace_to_python(self, node):
+    def comment_or_whitespace_to_python(self, node: Comment) -> typing.NoReturn:
         raise RuntimeError("Comments are not supported in the default loader!")
 
 

--- a/json5/loader.py
+++ b/json5/loader.py
@@ -4,10 +4,7 @@ import logging
 import typing
 from abc import abstractmethod
 from typing import Callable
-from typing import Dict
-from typing import List
 from typing import Literal
-from typing import Tuple
 
 from json5.model import *
 from json5.parser import parse_source
@@ -21,23 +18,23 @@ logger = logging.getLogger(__name__)
 class Environment:
     def __init__(
         self,
-        object_hook: Optional[Callable[[Dict[typing.Any, typing.Any]], typing.Any]] = None,
-        parse_float: Optional[Callable[[str], typing.Any]] = None,
-        parse_int: Optional[Callable[[str], typing.Any]] = None,
-        parse_constant: Optional[Callable[[Literal['-Infinity', 'Infinity', 'NaN']], typing.Any]] = None,
+        object_hook: Callable[[dict[typing.Any, typing.Any]], typing.Any] | None = None,
+        parse_float: Callable[[str], typing.Any] | None = None,
+        parse_int: Callable[[str], typing.Any] | None = None,
+        parse_constant: Callable[[Literal['-Infinity', 'Infinity', 'NaN']], typing.Any] | None = None,
         strict: bool = True,
-        object_pairs_hook: Optional[Callable[[List[Tuple[Union[str, JsonIdentifier], typing.Any]]], typing.Any]] = None,
-        parse_json5_identifiers: Optional[Callable[[JsonIdentifier], typing.Any]] = None,
+        object_pairs_hook: Callable[[list[tuple[Union[str, JsonIdentifier], typing.Any]]], typing.Any] | None = None,
+        parse_json5_identifiers: Callable[[JsonIdentifier], typing.Any] | None = None,
     ):
-        self.object_hook: Optional[Callable[[Dict[typing.Any, typing.Any]], typing.Any]] = object_hook
-        self.parse_float: Optional[Callable[[str], typing.Any]] = parse_float
-        self.parse_int: Optional[Callable[[str], typing.Any]] = parse_int
-        self.parse_constant: Optional[Callable[[Literal['-Infinity', 'Infinity', 'NaN']], typing.Any]] = parse_constant
+        self.object_hook: Callable[[dict[typing.Any, typing.Any]], typing.Any] | None = object_hook
+        self.parse_float: Callable[[str], typing.Any] | None = parse_float
+        self.parse_int: Callable[[str], typing.Any] | None = parse_int
+        self.parse_constant: Callable[[Literal['-Infinity', 'Infinity', 'NaN']], typing.Any] | None = parse_constant
         self.strict: bool = strict
-        self.object_pairs_hook: Optional[
-            Callable[[List[Tuple[Union[str, JsonIdentifier], typing.Any]]], typing.Any]
-        ] = object_pairs_hook
-        self.parse_json5_identifiers: Optional[Callable[[JsonIdentifier], typing.Any]] = parse_json5_identifiers
+        self.object_pairs_hook: None | (
+            Callable[[list[tuple[Union[str, JsonIdentifier], typing.Any]]], typing.Any]
+        ) = object_pairs_hook
+        self.parse_json5_identifiers: Callable[[JsonIdentifier], typing.Any] | None = parse_json5_identifiers
 
 
 class JsonIdentifier(str):
@@ -57,25 +54,23 @@ def load(f: typing.TextIO, **kwargs: typing.Any) -> typing.Any:
 
 
 @typing.overload
-def loads(
-    s: str, *, loader: None
-) -> typing.Union[int, float, str, dict[typing.Any, typing.Any], list[typing.Any], None,]:
+def loads(s: str, *, loader: None) -> int | float | str | dict[typing.Any, typing.Any] | list[typing.Any] | None:
     ...
 
 
 @typing.overload
 def loads(
     s: str, *, loader: DefaultLoader
-) -> typing.Union[int, float, str, dict[typing.Any, typing.Any], list[typing.Any], None,]:
+) -> int | float | str | dict[typing.Any, typing.Any] | list[typing.Any] | None:
     ...
 
 
 @typing.overload
-def loads(s: str, *, loader: typing.Optional[LoaderBase] = None, **kwargs: typing.Any) -> typing.Any:
+def loads(s: str, *, loader: LoaderBase | None = None, **kwargs: typing.Any) -> typing.Any:
     ...
 
 
-def loads(s: str, *, loader: typing.Optional[LoaderBase] = None, **kwargs: typing.Any) -> typing.Any:
+def loads(s: str, *, loader: LoaderBase | None = None, **kwargs: typing.Any) -> typing.Any:
     """
     Take a string of JSON text and deserialize it
 
@@ -97,7 +92,7 @@ def loads(s: str, *, loader: typing.Optional[LoaderBase] = None, **kwargs: typin
 
 
 class LoaderBase:
-    def __init__(self, env: typing.Optional[Environment] = None, **env_kwargs: typing.Any):
+    def __init__(self, env: Environment | None = None, **env_kwargs: typing.Any):
         if env is None:
             env = Environment(**env_kwargs)
         self.env: Environment = env

--- a/json5/model.py
+++ b/json5/model.py
@@ -1,19 +1,17 @@
+from __future__ import annotations
 import math
-from types import SimpleNamespace
-from functools import lru_cache
-from decimal import Decimal
+from typing import Optional, Union, List, Literal
+from .tokenizer import JSON5Token
 
 
-
-class Node(SimpleNamespace):
+class Node:
     excluded_names = ['excluded_names', 'wsc_before', 'wsc_after', 'leading_wsc']
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self):
         # Whitespace/Comments before/after the node
         self.wsc_before = []
         self.wsc_after = []
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         rep = (
             f"{self.__class__.__name__}("
             + ", ".join(
@@ -26,9 +24,10 @@ class Node(SimpleNamespace):
 
 
 class JSONText(Node):
-    def __init__(self, value):
+    def __init__(self, value: Value):
         assert isinstance(value, Value)
-        super().__init__(value=value)
+        self.value: Value = value
+        super().__init__()
 
 
 class Value(Node):
@@ -39,43 +38,57 @@ class Key(Node):
 
 
 class JSONObject(Value):
-    def __init__(self, *key_value_pairs, trailing_comma=None, leading_wsc=None, tok=None):
-        key_value_pairs = list(key_value_pairs)
-        for kvp in key_value_pairs:
+    def __init__(self, *key_value_pairs: KeyValuePair, trailing_comma: Optional[TrailingComma] = None, leading_wsc: Optional[List[Union[str, Comment]]] = None, tok: Optional[JSON5Token] = None):
+        kvps = list(key_value_pairs)
+        for kvp in kvps:
             assert isinstance(kvp, KeyValuePair), f"Expected key value pair, got {type(kvp)}"
         assert leading_wsc is None or all(isinstance(item, str) or isinstance(item, Comment) for item in leading_wsc)
-        super().__init__(key_value_pairs=key_value_pairs, trailing_comma=trailing_comma, leading_wsc=leading_wsc or [], tok=tok)
+        self.key_value_pairs: List[KeyValuePair] = kvps
+        self.trailing_comma: Optional[TrailingComma] = trailing_comma
+        self.leading_wsc: List[Union[str, Comment]] = leading_wsc or []
+        self.tok: Optional[JSON5Token] = tok
+        super().__init__()
 
 
 class JSONArray(Value):
-    def __init__(self, *values, trailing_comma=None, leading_wsc=None, tok=None):
-        values = list(values)
-        for value in values:
+    def __init__(self, *values: Value, trailing_comma: Optional[TrailingComma] = None, leading_wsc: Optional[List[Union[str, Comment]]] = None, tok: Optional[JSON5Token] = None):
+        vals = list(values)
+        for value in vals:
             assert isinstance(value, Value), f"Was expecting object with type Value. Got {type(value)}"
         assert leading_wsc is None or all(isinstance(item, str) or isinstance(item, Comment) for item in leading_wsc)
-        super().__init__(values=values, trailing_comma=trailing_comma, leading_wsc=leading_wsc or [], tok=tok)
+        self.values: List[Value] = vals
+        self.trailing_comma: Optional[TrailingComma] = trailing_comma
+        self.leading_wsc: List[Union[str, Comment]] = leading_wsc or []
+        self.tok: Optional[JSON5Token] = tok
+        super().__init__()
 
 
 class KeyValuePair(Node):
-    def __init__(self, key, value, tok=None):
+    def __init__(self, key: Key, value: Value, tok: Optional[JSON5Token] = None):
         assert isinstance(key, Key)
         assert isinstance(value, Value)
-        super().__init__(key=key, value=value, tok=tok)
+        self.key: Key = key
+        self.value: Value = value
+        self.tok: Optional[JSON5Token] = tok
+        super().__init__()
 
 
 class Identifier(Key):
-    def __init__(self, name, raw_value=None, tok=None):
+    def __init__(self, name: str, raw_value: Optional[str] = None, tok: Optional[JSON5Token] = None):
         assert isinstance(name, str)
         if raw_value is None:
             raw_value = name
         assert isinstance(raw_value, str)
         assert len(name) > 0
-        super().__init__(name=name, raw_value=raw_value, tok=tok)
+        self.name: str = name
+        self.raw_value: str = raw_value
+        self.tok: Optional[JSON5Token] = tok
+        super().__init__()
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash(self.name)
 
-    def __eq__(self, other):
+    def __eq__(self, other) -> bool:
         return hash(self) == hash(other)
 
 
@@ -84,7 +97,7 @@ class Number(Value):
 
 
 class Integer(Number):
-    def __init__(self, raw_value, is_hex=False, is_octal=False, tok=None):
+    def __init__(self, raw_value: str, is_hex: bool = False, is_octal: bool = False, tok: Optional[JSON5Token] = None):
         assert isinstance(raw_value, str)
         if is_hex and is_octal:
             raise ValueError("is_hex and is_octal are mutually exclusive")
@@ -97,31 +110,52 @@ class Integer(Number):
                 value = int(raw_value.replace('0', '0o', 1), 8)
         else:
             value = int(raw_value)
-        super().__init__(raw_value=raw_value, value=value, is_hex=is_hex, is_octal=is_octal, tok=tok)
+        self.value: int = value
+        self.raw_value: str = raw_value
+        self.is_hex: bool = is_hex
+        self.is_octal: bool = is_octal
+        self.tok: Optional[JSON5Token] = tok
+        super().__init__()
 
 
 class Float(Number):
-    def __init__(self, raw_value, exp_notation=None, tok=None):
+    def __init__(self, raw_value: str, exp_notation: Optional[Literal['e', 'E']] = None, tok: Optional[JSON5Token] = None):
         value = float(raw_value)
         assert exp_notation is None or exp_notation in ('e', 'E')
-        super().__init__(raw_value=raw_value, value=value, exp_notation=exp_notation, tok=tok)
+        self.raw_value: str = raw_value
+        self.exp_notation: Optional[Literal['e', 'E']] = exp_notation
+        self.tok: Optional[JSON5Token] = tok
+        self.value: float = value
+        super().__init__()
+
+
 
 
 class Infinity(Number):
-    def __init__(self, negative=False, tok=None):
-        super().__init__(negative=negative, tok=tok)
+    def __init__(self, negative: bool = False, tok: Optional[JSON5Token] = None):
+        self.negative: bool = negative
+        self.tok: Optional[JSON5Token] = tok
+        super().__init__()
 
     @property
-    def value(self):
+    def value(self) -> float:
         return math.inf if not self.negative else -math.inf
 
     @property
-    def const(self):
-        return '-Infinity' if self.negative else 'Infinity'
+    def const(self) -> Literal['Infinity', '-Infinity']:
+        if self.negative:
+            return '-Infinity'
+        else:
+            return 'Infinity'
 
 class NaN(Number):
-    def __init__(self, tok=None):
-        super().__init__(value=math.nan, tok=tok)
+    def __init__(self, tok: Optional[JSON5Token] = None):
+        self.tok: Optional[JSON5Token] = tok
+        super().__init__()
+
+    @property
+    def value(self) -> float:
+        return math.nan
 
     @property
     def const(self):
@@ -131,46 +165,59 @@ class String(Value, Key):
     ...
 
 class DoubleQuotedString(String):
-    def __init__(self, characters, raw_value, tok=None):
+    def __init__(self, characters, raw_value, tok: Optional[JSON5Token] = None):
         assert isinstance(raw_value, str)
-        characters = characters
         assert isinstance(characters, str)
-        super().__init__(characters=characters, raw_value=raw_value, tok=tok)
+        self.characters: str = characters
+        self.raw_value: str = raw_value
+        self.tok: Optional[JSON5Token] = tok
+        super().__init__()
 
 
 class SingleQuotedString(String):
-    def __init__(self, characters, raw_value, tok=None):
+    def __init__(self, characters: str, raw_value: str, tok: Optional[JSON5Token] = None):
         assert isinstance(raw_value, str)
-        characters = characters
         assert isinstance(characters, str)
-        super().__init__(characters=characters, raw_value=raw_value, tok=tok)
+        self.characters: str = characters
+        self.raw_value: str = raw_value
+        self.tok: Optional[JSON5Token] = tok
+        super().__init__()
 
 
 class BooleanLiteral(Value):
-    def __init__(self, value, tok=None):
+    def __init__(self, value, tok: Optional[JSON5Token] = None):
         assert value in (True, False)
-        super().__init__(value=value, tok=tok)
+        self.value: bool = value
+        self.tok: Optional[JSON5Token] = tok
+        super().__init__()
 
 
 class NullLiteral(Value):
-    def __init__(self, tok=None):
-        super().__init__(value=None, tok=tok)
-
+    value = None
+    def __init__(self, tok: Optional[JSON5Token] = None):
+        self.tok: Optional[JSON5Token] = None
+        super().__init__()
 
 class UnaryOp(Value):
-    def __init__(self, op, value, tok=None):
+    def __init__(self, op: Literal['-', '+'], value: Number, tok: Optional[JSON5Token] = None):
         assert op in ('-', '+')
         assert isinstance(value, Number)
-        super().__init__(op=op, value=value, tok=tok)
+        self.op: Literal['-', '+'] = op
+        self.value: Number = value
+        self.tok: Optional[JSON5Token] = tok
+        super().__init__()
 
 class TrailingComma(Node):
-    def __init__(self, tok=None):
-        super().__init__(tok=tok)
+    def __init__(self, tok: Optional[JSON5Token] = None):
+        self.tok = tok
+        super().__init__()
 
 class Comment(Node):
-    def __init__(self, value, tok=None):
+    def __init__(self, value: str, tok=None):
         assert isinstance(value, str), f"Expected str got {type(value)}"
-        super().__init__(value=value, tok=tok)
+        self.value: str = value
+        self.tok: Optional[JSON5Token] = tok
+        super().__init__()
 
 
 class LineComment(Comment):

--- a/json5/model.py
+++ b/json5/model.py
@@ -2,10 +2,7 @@ from __future__ import annotations
 
 import math
 from typing import Any
-from typing import List
 from typing import Literal
-from typing import Optional
-from typing import Union
 
 from .tokenizer import JSON5Token
 
@@ -41,16 +38,14 @@ class Node:
 
     def __init__(self) -> None:
         # Whitespace/Comments before/after the node
-        self.wsc_before: List[Union[str, Comment]] = []
-        self.wsc_after: List[Union[str, Comment]] = []
+        self.wsc_before: list[str | Comment] = []
+        self.wsc_after: list[str | Comment] = []
 
     def __repr__(self) -> str:
         rep = (
             f"{self.__class__.__name__}("
             + ", ".join(
-                "{key}={value}".format(key=key, value=repr(value))
-                for key, value in self.__dict__.items()
-                if key not in self.excluded_names
+                f"{key}={repr(value)}" for key, value in self.__dict__.items() if key not in self.excluded_names
             )
             + ")"
         )
@@ -76,18 +71,18 @@ class JSONObject(Value):
     def __init__(
         self,
         *key_value_pairs: KeyValuePair,
-        trailing_comma: Optional[TrailingComma] = None,
-        leading_wsc: Optional[List[Union[str, Comment]]] = None,
-        tok: Optional[JSON5Token] = None,
+        trailing_comma: TrailingComma | None = None,
+        leading_wsc: list[str | Comment] | None = None,
+        tok: JSON5Token | None = None,
     ):
         kvps = list(key_value_pairs)
         for kvp in kvps:
             assert isinstance(kvp, KeyValuePair), f"Expected key value pair, got {type(kvp)}"
         assert leading_wsc is None or all(isinstance(item, str) or isinstance(item, Comment) for item in leading_wsc)
-        self.key_value_pairs: List[KeyValuePair] = kvps
-        self.trailing_comma: Optional[TrailingComma] = trailing_comma
-        self.leading_wsc: List[Union[str, Comment]] = leading_wsc or []
-        self.tok: Optional[JSON5Token] = tok
+        self.key_value_pairs: list[KeyValuePair] = kvps
+        self.trailing_comma: TrailingComma | None = trailing_comma
+        self.leading_wsc: list[str | Comment] = leading_wsc or []
+        self.tok: JSON5Token | None = tok
         super().__init__()
 
 
@@ -95,33 +90,33 @@ class JSONArray(Value):
     def __init__(
         self,
         *values: Value,
-        trailing_comma: Optional[TrailingComma] = None,
-        leading_wsc: Optional[List[Union[str, Comment]]] = None,
-        tok: Optional[JSON5Token] = None,
+        trailing_comma: TrailingComma | None = None,
+        leading_wsc: list[str | Comment] | None = None,
+        tok: JSON5Token | None = None,
     ):
         vals = list(values)
         for value in vals:
             assert isinstance(value, Value), f"Was expecting object with type Value. Got {type(value)}"
         assert leading_wsc is None or all(isinstance(item, str) or isinstance(item, Comment) for item in leading_wsc)
-        self.values: List[Value] = vals
-        self.trailing_comma: Optional[TrailingComma] = trailing_comma
-        self.leading_wsc: List[Union[str, Comment]] = leading_wsc or []
-        self.tok: Optional[JSON5Token] = tok
+        self.values: list[Value] = vals
+        self.trailing_comma: TrailingComma | None = trailing_comma
+        self.leading_wsc: list[str | Comment] = leading_wsc or []
+        self.tok: JSON5Token | None = tok
         super().__init__()
 
 
 class KeyValuePair(Node):
-    def __init__(self, key: Key, value: Value, tok: Optional[JSON5Token] = None):
+    def __init__(self, key: Key, value: Value, tok: JSON5Token | None = None):
         assert isinstance(key, Key)
         assert isinstance(value, Value)
         self.key: Key = key
         self.value: Value = value
-        self.tok: Optional[JSON5Token] = tok
+        self.tok: JSON5Token | None = tok
         super().__init__()
 
 
 class Identifier(Key):
-    def __init__(self, name: str, raw_value: Optional[str] = None, tok: Optional[JSON5Token] = None):
+    def __init__(self, name: str, raw_value: str | None = None, tok: JSON5Token | None = None):
         assert isinstance(name, str)
         if raw_value is None:
             raw_value = name
@@ -129,7 +124,7 @@ class Identifier(Key):
         assert len(name) > 0
         self.name: str = name
         self.raw_value: str = raw_value
-        self.tok: Optional[JSON5Token] = tok
+        self.tok: JSON5Token | None = tok
         super().__init__()
 
     def __hash__(self) -> int:
@@ -144,7 +139,7 @@ class Number(Value):
 
 
 class Integer(Number):
-    def __init__(self, raw_value: str, is_hex: bool = False, is_octal: bool = False, tok: Optional[JSON5Token] = None):
+    def __init__(self, raw_value: str, is_hex: bool = False, is_octal: bool = False, tok: JSON5Token | None = None):
         assert isinstance(raw_value, str)
         if is_hex and is_octal:
             raise ValueError("is_hex and is_octal are mutually exclusive")
@@ -161,25 +156,25 @@ class Integer(Number):
         self.raw_value: str = raw_value
         self.is_hex: bool = is_hex
         self.is_octal: bool = is_octal
-        self.tok: Optional[JSON5Token] = tok
+        self.tok: JSON5Token | None = tok
         super().__init__()
 
 
 class Float(Number):
-    def __init__(self, raw_value: str, exp_notation: Optional[str] = None, tok: Optional[JSON5Token] = None):
+    def __init__(self, raw_value: str, exp_notation: str | None = None, tok: JSON5Token | None = None):
         value = float(raw_value)
         assert exp_notation is None or exp_notation in ('e', 'E')
         self.raw_value: str = raw_value
-        self.exp_notation: Optional[str] = exp_notation
-        self.tok: Optional[JSON5Token] = tok
+        self.exp_notation: str | None = exp_notation
+        self.tok: JSON5Token | None = tok
         self.value: float = value
         super().__init__()
 
 
 class Infinity(Number):
-    def __init__(self, negative: bool = False, tok: Optional[JSON5Token] = None):
+    def __init__(self, negative: bool = False, tok: JSON5Token | None = None):
         self.negative: bool = negative
-        self.tok: Optional[JSON5Token] = tok
+        self.tok: JSON5Token | None = tok
         super().__init__()
 
     @property
@@ -195,8 +190,8 @@ class Infinity(Number):
 
 
 class NaN(Number):
-    def __init__(self, tok: Optional[JSON5Token] = None):
-        self.tok: Optional[JSON5Token] = tok
+    def __init__(self, tok: JSON5Token | None = None):
+        self.tok: JSON5Token | None = tok
         super().__init__()
 
     @property
@@ -213,62 +208,62 @@ class String(Value, Key):
 
 
 class DoubleQuotedString(String):
-    def __init__(self, characters: str, raw_value: str, tok: Optional[JSON5Token] = None):
+    def __init__(self, characters: str, raw_value: str, tok: JSON5Token | None = None):
         assert isinstance(raw_value, str)
         assert isinstance(characters, str)
         self.characters: str = characters
         self.raw_value: str = raw_value
-        self.tok: Optional[JSON5Token] = tok
+        self.tok: JSON5Token | None = tok
         super().__init__()
 
 
 class SingleQuotedString(String):
-    def __init__(self, characters: str, raw_value: str, tok: Optional[JSON5Token] = None):
+    def __init__(self, characters: str, raw_value: str, tok: JSON5Token | None = None):
         assert isinstance(raw_value, str)
         assert isinstance(characters, str)
         self.characters: str = characters
         self.raw_value: str = raw_value
-        self.tok: Optional[JSON5Token] = tok
+        self.tok: JSON5Token | None = tok
         super().__init__()
 
 
 class BooleanLiteral(Value):
-    def __init__(self, value: bool, tok: Optional[JSON5Token] = None):
+    def __init__(self, value: bool, tok: JSON5Token | None = None):
         assert value in (True, False)
         self.value: bool = value
-        self.tok: Optional[JSON5Token] = tok
+        self.tok: JSON5Token | None = tok
         super().__init__()
 
 
 class NullLiteral(Value):
     value = None
 
-    def __init__(self, tok: Optional[JSON5Token] = None):
-        self.tok: Optional[JSON5Token] = None
+    def __init__(self, tok: JSON5Token | None = None):
+        self.tok: JSON5Token | None = None
         super().__init__()
 
 
 class UnaryOp(Value):
-    def __init__(self, op: Literal['-', '+'], value: Number, tok: Optional[JSON5Token] = None):
+    def __init__(self, op: Literal['-', '+'], value: Number, tok: JSON5Token | None = None):
         assert op in ('-', '+')
         assert isinstance(value, Number)
         self.op: Literal['-', '+'] = op
         self.value: Number = value
-        self.tok: Optional[JSON5Token] = tok
+        self.tok: JSON5Token | None = tok
         super().__init__()
 
 
 class TrailingComma(Node):
-    def __init__(self, tok: Optional[JSON5Token] = None):
+    def __init__(self, tok: JSON5Token | None = None):
         self.tok = tok
         super().__init__()
 
 
 class Comment(Node):
-    def __init__(self, value: str, tok: Optional[JSON5Token] = None):
+    def __init__(self, value: str, tok: JSON5Token | None = None):
         assert isinstance(value, str), f"Expected str got {type(value)}"
         self.value: str = value
-        self.tok: Optional[JSON5Token] = tok
+        self.tok: JSON5Token | None = tok
         super().__init__()
 
 

--- a/json5/model.py
+++ b/json5/model.py
@@ -1,15 +1,40 @@
 from __future__ import annotations
 import math
-from typing import Optional, Union, List, Literal
+from typing import Optional, Union, List, Literal, Any
 from .tokenizer import JSON5Token
 
+__all__ = [
+    'Node',
+    'JSONText',
+    'Value',
+    'Key',
+    'JSONObject',
+    'JSONArray',
+    'KeyValuePair',
+    'Identifier',
+    'Number',
+    'Integer',
+    'Float',
+    'Infinity',
+    'NaN',
+    'String',
+    'DoubleQuotedString',
+    'SingleQuotedString',
+    'BooleanLiteral',
+    'NullLiteral',
+    'UnaryOp',
+    'TrailingComma',
+    'Comment',
+    'LineComment',
+    'BlockComment',
+]
 
 class Node:
     excluded_names = ['excluded_names', 'wsc_before', 'wsc_after', 'leading_wsc']
-    def __init__(self):
+    def __init__(self) -> None:
         # Whitespace/Comments before/after the node
-        self.wsc_before = []
-        self.wsc_after = []
+        self.wsc_before: List[Union[str, Comment]] = []
+        self.wsc_after: List[Union[str, Comment]] = []
 
     def __repr__(self) -> str:
         rep = (
@@ -88,7 +113,7 @@ class Identifier(Key):
     def __hash__(self) -> int:
         return hash(self.name)
 
-    def __eq__(self, other) -> bool:
+    def __eq__(self, other: Any) -> bool:
         return hash(self) == hash(other)
 
 
@@ -119,11 +144,11 @@ class Integer(Number):
 
 
 class Float(Number):
-    def __init__(self, raw_value: str, exp_notation: Optional[Literal['e', 'E']] = None, tok: Optional[JSON5Token] = None):
+    def __init__(self, raw_value: str, exp_notation: Optional[str] = None, tok: Optional[JSON5Token] = None):
         value = float(raw_value)
         assert exp_notation is None or exp_notation in ('e', 'E')
         self.raw_value: str = raw_value
-        self.exp_notation: Optional[Literal['e', 'E']] = exp_notation
+        self.exp_notation: Optional[str] = exp_notation
         self.tok: Optional[JSON5Token] = tok
         self.value: float = value
         super().__init__()
@@ -158,14 +183,14 @@ class NaN(Number):
         return math.nan
 
     @property
-    def const(self):
+    def const(self) -> Literal['NaN']:
         return 'NaN'
 
 class String(Value, Key):
     ...
 
 class DoubleQuotedString(String):
-    def __init__(self, characters, raw_value, tok: Optional[JSON5Token] = None):
+    def __init__(self, characters: str, raw_value: str, tok: Optional[JSON5Token] = None):
         assert isinstance(raw_value, str)
         assert isinstance(characters, str)
         self.characters: str = characters
@@ -185,7 +210,7 @@ class SingleQuotedString(String):
 
 
 class BooleanLiteral(Value):
-    def __init__(self, value, tok: Optional[JSON5Token] = None):
+    def __init__(self, value: bool, tok: Optional[JSON5Token] = None):
         assert value in (True, False)
         self.value: bool = value
         self.tok: Optional[JSON5Token] = tok
@@ -213,7 +238,7 @@ class TrailingComma(Node):
         super().__init__()
 
 class Comment(Node):
-    def __init__(self, value: str, tok=None):
+    def __init__(self, value: str, tok: Optional[JSON5Token] = None):
         assert isinstance(value, str), f"Expected str got {type(value)}"
         self.value: str = value
         self.tok: Optional[JSON5Token] = tok

--- a/json5/model.py
+++ b/json5/model.py
@@ -1,6 +1,12 @@
 from __future__ import annotations
+
 import math
-from typing import Optional, Union, List, Literal, Any
+from typing import Any
+from typing import List
+from typing import Literal
+from typing import Optional
+from typing import Union
+
 from .tokenizer import JSON5Token
 
 __all__ = [
@@ -29,8 +35,10 @@ __all__ = [
     'BlockComment',
 ]
 
+
 class Node:
     excluded_names = ['excluded_names', 'wsc_before', 'wsc_after', 'leading_wsc']
+
     def __init__(self) -> None:
         # Whitespace/Comments before/after the node
         self.wsc_before: List[Union[str, Comment]] = []
@@ -41,7 +49,8 @@ class Node:
             f"{self.__class__.__name__}("
             + ", ".join(
                 "{key}={value}".format(key=key, value=repr(value))
-                for key, value in self.__dict__.items() if key not in self.excluded_names
+                for key, value in self.__dict__.items()
+                if key not in self.excluded_names
             )
             + ")"
         )
@@ -58,12 +67,19 @@ class JSONText(Node):
 class Value(Node):
     pass
 
+
 class Key(Node):
     ...
 
 
 class JSONObject(Value):
-    def __init__(self, *key_value_pairs: KeyValuePair, trailing_comma: Optional[TrailingComma] = None, leading_wsc: Optional[List[Union[str, Comment]]] = None, tok: Optional[JSON5Token] = None):
+    def __init__(
+        self,
+        *key_value_pairs: KeyValuePair,
+        trailing_comma: Optional[TrailingComma] = None,
+        leading_wsc: Optional[List[Union[str, Comment]]] = None,
+        tok: Optional[JSON5Token] = None,
+    ):
         kvps = list(key_value_pairs)
         for kvp in kvps:
             assert isinstance(kvp, KeyValuePair), f"Expected key value pair, got {type(kvp)}"
@@ -76,7 +92,13 @@ class JSONObject(Value):
 
 
 class JSONArray(Value):
-    def __init__(self, *values: Value, trailing_comma: Optional[TrailingComma] = None, leading_wsc: Optional[List[Union[str, Comment]]] = None, tok: Optional[JSON5Token] = None):
+    def __init__(
+        self,
+        *values: Value,
+        trailing_comma: Optional[TrailingComma] = None,
+        leading_wsc: Optional[List[Union[str, Comment]]] = None,
+        tok: Optional[JSON5Token] = None,
+    ):
         vals = list(values)
         for value in vals:
             assert isinstance(value, Value), f"Was expecting object with type Value. Got {type(value)}"
@@ -154,8 +176,6 @@ class Float(Number):
         super().__init__()
 
 
-
-
 class Infinity(Number):
     def __init__(self, negative: bool = False, tok: Optional[JSON5Token] = None):
         self.negative: bool = negative
@@ -173,6 +193,7 @@ class Infinity(Number):
         else:
             return 'Infinity'
 
+
 class NaN(Number):
     def __init__(self, tok: Optional[JSON5Token] = None):
         self.tok: Optional[JSON5Token] = tok
@@ -186,8 +207,10 @@ class NaN(Number):
     def const(self) -> Literal['NaN']:
         return 'NaN'
 
+
 class String(Value, Key):
     ...
+
 
 class DoubleQuotedString(String):
     def __init__(self, characters: str, raw_value: str, tok: Optional[JSON5Token] = None):
@@ -219,9 +242,11 @@ class BooleanLiteral(Value):
 
 class NullLiteral(Value):
     value = None
+
     def __init__(self, tok: Optional[JSON5Token] = None):
         self.tok: Optional[JSON5Token] = None
         super().__init__()
+
 
 class UnaryOp(Value):
     def __init__(self, op: Literal['-', '+'], value: Number, tok: Optional[JSON5Token] = None):
@@ -232,10 +257,12 @@ class UnaryOp(Value):
         self.tok: Optional[JSON5Token] = tok
         super().__init__()
 
+
 class TrailingComma(Node):
     def __init__(self, tok: Optional[JSON5Token] = None):
         self.tok = tok
         super().__init__()
+
 
 class Comment(Node):
     def __init__(self, value: str, tok: Optional[JSON5Token] = None):
@@ -247,6 +274,7 @@ class Comment(Node):
 
 class LineComment(Comment):
     ...
+
 
 class BlockComment(Comment):
     ...

--- a/json5/parser.py
+++ b/json5/parser.py
@@ -1,3 +1,8 @@
+from __future__ import annotations
+
+import typing
+from typing import Protocol
+
 import regex as re
 
 import sys
@@ -10,8 +15,8 @@ from json5.utils import JSON5DecodeError
 import ast
 from functools import lru_cache
 
-class QuietSlyLogger(SlyLogger):
-    def warning(self, *args, **kwargs):
+class QuietSlyLogger(SlyLogger):  # type: ignore[misc]
+    def warning(self, *args: Any, **kwargs: Any) -> None:
         return
     debug = warning
     info = warning
@@ -33,7 +38,7 @@ ESCAPE_SEQUENCES = {
 # class TrailingComma:
 #     pass
 
-def replace_escape_literals(matchobj):
+def replace_escape_literals(matchobj: re.Match[str]) -> str:
     s = matchobj.group(0)
     if s.startswith('\\0') and len(s) == 3:
         raise JSON5DecodeError("'\\0' MUST NOT be followed by a decimal digit", None)
@@ -42,42 +47,134 @@ def replace_escape_literals(matchobj):
 
 
 @lru_cache(maxsize=1024)
-def _latin_escape_replace(s):
+def _latin_escape_replace(s: str) -> str:
     if s.startswith('\\x') and len(s) != 4:
         raise JSON5DecodeError("'\\x' MUST be followed by two hexadecimal digits", None)
-    val = ast.literal_eval(f'"{s}"')
+    val: str = ast.literal_eval(f'"{s}"')
     if val == '\\':
         val = '\\\\'  # this is important; the subsequent regex will sub it back to \\
     return val
 
 
-def latin_unicode_escape_replace(matchobj):
+def latin_unicode_escape_replace(matchobj: re.Match[str]) -> str:
     s = matchobj.group(0)
     return _latin_escape_replace(s)
 
 
-def _unicode_escape_replace(s):
-    return ast.literal_eval(f'"{s}"')
+def _unicode_escape_replace(s: str) -> str:
+    ret: str = ast.literal_eval(f'"{s}"')
+    return ret
 
-def unicode_escape_replace(matchobj):
+def unicode_escape_replace(matchobj: re.Match[str]) -> str:
     s = matchobj.group(0)
     return _unicode_escape_replace(s)
 
-class JSONParser(Parser):
+
+class T_TextProduction(Protocol):
+    wsc0: List[Union[Comment, str]]
+    wsc1: List[Union[Comment, str]]
+    def __getitem__(self, i: Literal[1]) -> Value: ...
+
+class T_TokenSlice(Protocol):
+    def __getitem__(self, item: int) -> JSON5Token: ...
+
+class T_FirstKeyValuePairProduction(Protocol):
+    wsc0: List[Union[Comment, str]]
+    wsc1: List[Union[Comment, str]]
+    wsc2: List[Union[Comment, str]]
+    key: Key
+    value: Value
+    def __getitem__(self, item: int) -> Union[Key, Value]: ...
+
+class T_WSCProduction(Protocol):
+    def __getitem__(self, item: Literal[0]) -> Union[str, Comment]: ...
+
+class T_CommentProduction(Protocol):
+    def __getitem__(self, item: Literal[0]) -> str: ...
+    _slice: T_TokenSlice
+
+
+class T_KeyValuePairsProduction(Protocol):
+    first_key_value_pair: KeyValuePair
+    subsequent_key_value_pair: List[KeyValuePair]
+
+class T_JsonObjectProduction(Protocol):
+    key_value_pairs: Optional[typing.Tuple[List[KeyValuePair], Optional[TrailingComma]]]
+    _slice: T_TokenSlice
+    wsc: List[Union[Comment, str]]
+
+class SubsequentKeyValuePairProduction(Protocol):
+    wsc: List[Union[Comment, str]]
+    first_key_value_pair: Optional[KeyValuePair]
+    _slice: T_TokenSlice
+
+class T_FirstArrayValueProduction(Protocol):
+    def __getitem__(self, item: Literal[1]) -> Value: ...
+    wsc: List[Union[Comment, str]]
+
+class T_SubsequentArrayValueProduction(Protocol):
+    first_array_value: Optional[Value]
+    wsc: List[Union[Comment, str]]
+    _slice: T_TokenSlice
+
+class T_ArrayValuesProduction(Protocol):
+    first_array_value: Value
+    subsequent_array_value: List[Value]
+
+class T_JsonArrayProduction(Protocol):
+    array_values: Optional[typing.Tuple[List[Value], Optional[TrailingComma]]]
+    _slice: T_TokenSlice
+    wsc: List[Union[Comment, str]]
+
+class T_IdentifierProduction(Protocol):
+    def __getitem__(self, item: Literal[0]) -> str: ...
+    _slice: T_TokenSlice
+
+class T_KeyProduction(Protocol):
+    def __getitem__(self, item: Literal[1]) -> Key: ...
+
+class T_NumberProduction(Protocol):
+    def __getitem__(self, item: Literal[0]) -> str: ...
+    _slice: T_TokenSlice
+
+class T_ValueNumberProduction(Protocol):
+    number: Union[Infinity, NaN, Float, Integer]
+
+class T_ExponentNotationProduction(Protocol):
+    def __getitem__(self, item: int) -> str:...
+
+class T_StringTokenProduction(Protocol):
+    def __getitem__(self, item: Literal[0]) -> str:...
+    _slice: T_TokenSlice
+
+class T_StringProduction(Protocol):
+    def __getitem__(self, item: Literal[0]) -> Union[DoubleQuotedString, SingleQuotedString]: ...
+
+class T_ValueProduction(Protocol):
+    def __getitem__(self, item: Literal[0]) -> Union[DoubleQuotedString, SingleQuotedString, JSONObject, JSONArray, BooleanLiteral, NullLiteral, Infinity, Integer, Float, NaN]: ...
+
+
+T_CallArg = typing.TypeVar('T_CallArg')
+_: typing.Callable[..., typing.Callable[[T_CallArg], T_CallArg]]
+
+
+
+
+class JSONParser(Parser):  # type: ignore[misc]
     # debugfile = 'parser.out'
     tokens = JSONLexer.tokens
     log = QuietSlyLogger(sys.stderr)
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any):
         super().__init__(*args, **kwargs)
-        self.errors = []
-        self.last_token = None
-        self.seen_tokens = []
-        self.expecting = []
+        self.errors: List[JSON5DecodeError] = []
+        self.last_token: Optional[JSON5Token] = None
+        self.seen_tokens: List[JSON5Token] = []
+        self.expecting: List[str] = []
 
 
     @_('{ wsc } value { wsc }')
-    def text(self, p):
+    def text(self, p: T_TextProduction) -> JSONText:
         node = JSONText(value=p[1])
         for wsc in p.wsc0:
             node.wsc_before.append(wsc)
@@ -86,7 +183,7 @@ class JSONParser(Parser):
         return node
 
     @_('key { wsc } seen_colon COLON { wsc } object_value_seen value { wsc }')
-    def first_key_value_pair(self, p):
+    def first_key_value_pair(self, p: T_FirstKeyValuePairProduction) -> KeyValuePair:
         key = p[0]
         for wsc in p.wsc0:
             key.wsc_after.append(wsc)
@@ -99,7 +196,8 @@ class JSONParser(Parser):
 
 
     @_('object_delimiter_seen COMMA { wsc } [ first_key_value_pair ]')
-    def subsequent_key_value_pair(self, p):
+    def subsequent_key_value_pair(self, p: SubsequentKeyValuePairProduction) -> Union[KeyValuePair, TrailingComma]:
+        node: Union[KeyValuePair, TrailingComma]
         if p.first_key_value_pair:
             node = p.first_key_value_pair
             for wsc in p.wsc:
@@ -113,22 +211,22 @@ class JSONParser(Parser):
 
     @_('WHITESPACE',
        'comment')
-    def wsc(self, p):
+    def wsc(self, p: T_WSCProduction) -> Union[str, Comment]:
         return p[0]
 
     @_('BLOCK_COMMENT')
-    def comment(self, p):
+    def comment(self, p: T_CommentProduction) -> BlockComment:
         return BlockComment(p[0], tok=p._slice[0])
 
 
     @_('LINE_COMMENT') # type: ignore[no-redef]
-    def comment(self, p):
+    def comment(self, p: T_CommentProduction):
         return LineComment(p[0], tok=p._slice[0])
 
 
 
     @_('first_key_value_pair { subsequent_key_value_pair }')
-    def key_value_pairs(self, p):
+    def key_value_pairs(self, p: T_KeyValuePairsProduction) -> typing.Tuple[List[KeyValuePair], Optional[TrailingComma]]:
         ret = [p.first_key_value_pair, ]
         num_sqvp = len(p.subsequent_key_value_pair)
         for index, value in enumerate(p.subsequent_key_value_pair):
@@ -142,36 +240,36 @@ class JSONParser(Parser):
         return ret, None
 
     @_('')
-    def seen_LBRACE(self, p):
+    def seen_LBRACE(self, p: Any) -> None:
         self.expecting.append(['RBRACE', 'key'])
 
     @_('')
-    def seen_key(self, p):
+    def seen_key(self, p: Any) -> None:
         self.expecting.pop()
         self.expecting.append(['COLON'])
 
     @_('')
-    def seen_colon(self, p):
+    def seen_colon(self, p: Any) -> None:
         self.expecting.pop()
         self.expecting.append(['value'])
 
     @_('')
-    def object_value_seen(self, p):
+    def object_value_seen(self, p: Any) -> None:
         self.expecting.pop()
         self.expecting.append(['COMMA', 'RBRACE'])
 
     @_('')
-    def object_delimiter_seen(self, p):
+    def object_delimiter_seen(self, p: Any) -> None:
         self.expecting.pop()
         self.expecting.append(['RBRACE', 'key'])
 
     @_('')
-    def seen_RBRACE(self, p):
+    def seen_RBRACE(self, p: Any) -> None:
         self.expecting.pop()
 
 
     @_('seen_LBRACE LBRACE { wsc } [ key_value_pairs ] seen_RBRACE RBRACE')
-    def json_object(self, p):
+    def json_object(self, p: T_JsonObjectProduction) -> JSONObject:
         if not p.key_value_pairs:
             node = JSONObject(leading_wsc=list(p.wsc or []), tok=p._slice[0])
         else:
@@ -181,14 +279,15 @@ class JSONParser(Parser):
         return node
 
     @_('array_value_seen value { wsc }')
-    def first_array_value(self, p):
+    def first_array_value(self, p: T_FirstArrayValueProduction) -> Value:
         node = p[1]
         for wsc in p.wsc:
             node.wsc_after.append(wsc)
         return node
 
     @_('array_delimiter_seen COMMA { wsc } [ first_array_value ]')
-    def subsequent_array_value(self, p):
+    def subsequent_array_value(self, p: T_SubsequentArrayValueProduction) -> Union[Value, TrailingComma]:
+        node: Union[Value, TrailingComma]
         if p.first_array_value:
             node = p.first_array_value
             for wsc in p.wsc:
@@ -200,7 +299,7 @@ class JSONParser(Parser):
         return node
 
     @_('first_array_value { subsequent_array_value }')
-    def array_values(self, p):
+    def array_values(self, p: T_ArrayValuesProduction) -> typing.Tuple[List[Value], Optional[TrailingComma]]:
         ret = [p.first_array_value, ]
         num_values = len(p.subsequent_array_value)
         for index, value in enumerate(p.subsequent_array_value):
@@ -215,7 +314,7 @@ class JSONParser(Parser):
 
 
     @_('seen_LBRACKET LBRACKET { wsc } [ array_values ] seen_RBRACKET RBRACKET')
-    def json_array(self, p):
+    def json_array(self, p: T_JsonArrayProduction) -> JSONArray:
         if not p.array_values:
             node = JSONArray(tok=p._slice[1])
         else:
@@ -228,21 +327,21 @@ class JSONParser(Parser):
         return node
 
     @_('')
-    def seen_LBRACKET(self, p):
+    def seen_LBRACKET(self, p: Any) -> None:
         self.expecting.append(['RBRACKET', 'value'])
 
     @_('')
-    def seen_RBRACKET(self, p):
+    def seen_RBRACKET(self, p: Any) -> None:
         self.expecting.pop()
 
     @_('')
-    def array_delimiter_seen(self, p):
+    def array_delimiter_seen(self, p: Any) -> None:
         assert len(self.expecting[-1]) == 2
         self.expecting[-1].pop()
         self.expecting[-1].append('value')
 
     @_('')
-    def array_value_seen(self, p):
+    def array_value_seen(self, p: Any) -> None:
         assert len(self.expecting[-1]) == 2
         assert self.expecting[-1][-1] == 'value'
         self.expecting[-1].pop()
@@ -250,7 +349,7 @@ class JSONParser(Parser):
 
 
     @_('NAME')
-    def identifier(self, p):
+    def identifier(self, p: T_IdentifierProduction) -> Identifier:
         raw_value = p[0]
         name = re.sub(r'\\u[0-9a-fA-F]{4}', unicode_escape_replace, raw_value)
         pattern = r'[\w_\$]([\w_\d\$\p{Pc}\p{Mn}\p{Mc}\u200C\u200D])*'
@@ -260,20 +359,20 @@ class JSONParser(Parser):
 
     @_('seen_key identifier',
        'seen_key string')
-    def key(self, p):
+    def key(self, p: T_KeyProduction) -> Union[Identifier, DoubleQuotedString, SingleQuotedString]:
         node = p[1]
         return node
 
     @_('INTEGER')
-    def number(self, p):
+    def number(self, p: T_NumberProduction):
         return Integer(p[0], tok=p._slice[0])
 
     @_('FLOAT')  # type: ignore[no-redef]
-    def number(self, p):
+    def number(self, p: T_NumberProduction):
         return Float(p[0], tok=p._slice[0])
 
     @_('OCTAL')  # type: ignore[no-redef]
-    def number(self, p):
+    def number(self, p: T_NumberProduction):
         self.errors.append(JSON5DecodeError("Invalid integer literal. Octals are not allowed", p._slice[0]))
         raw_value = p[0]
         if re.search(r'[89]+', raw_value):
@@ -284,37 +383,37 @@ class JSONParser(Parser):
 
 
     @_('INFINITY')  # type: ignore[no-redef]
-    def number(self, p):
+    def number(self, p: Any) -> Infinity:
         return Infinity()
 
     @_('NAN')  # type: ignore[no-redef]
-    def number(self, p):
+    def number(self, p: Any) -> NaN:
         return NaN()
 
     @_('MINUS number')
-    def value(self, p):
+    def value(self, p: T_ValueNumberProduction) -> UnaryOp:
         if isinstance(p.number, Infinity):
             p.number.negative = True
         node = UnaryOp(op='-', value=p.number)
         return node
 
     @_('PLUS number')  # type: ignore[no-redef]
-    def value(self, p):
+    def value(self, p: T_ValueNumberProduction):
         node = UnaryOp(op='+', value=p.number)
         return node
 
     @_('INTEGER EXPONENT',  # type: ignore[no-redef]
        'FLOAT EXPONENT')
-    def number(self, p):
+    def number(self, p: T_ExponentNotationProduction) -> Float:
         exp_notation = p[1][0]  # e or E
         return Float(p[0]+p[1], exp_notation=exp_notation)
 
     @_('HEXADECIMAL')  # type: ignore[no-redef]
-    def number(self, p):
+    def number(self, p: T_NumberProduction) -> Integer:
         return Integer(p[0], is_hex=True)
 
     @_('DOUBLE_QUOTE_STRING')
-    def double_quoted_string(self, p):
+    def double_quoted_string(self, p: T_StringTokenProduction) -> DoubleQuotedString:
         raw_value = p[0]
         contents = raw_value[1:-1]
         terminator_in_string = re.search(r'(?<!\\)([\u000D\u2028\u2029]|(?<!\r)\n)', contents)
@@ -341,7 +440,7 @@ class JSONParser(Parser):
         return DoubleQuotedString(contents, raw_value=raw_value, tok=p._slice[0])
 
     @_("SINGLE_QUOTE_STRING")
-    def single_quoted_string(self, p):
+    def single_quoted_string(self, p: T_StringTokenProduction) -> SingleQuotedString:
         raw_value = p[0]
         contents = raw_value[1:-1]
         terminator_in_string = re.search(r'(?<!\\)([\u000D\u2028\u2029]|(?<!\r)\n)', contents)
@@ -369,19 +468,19 @@ class JSONParser(Parser):
 
     @_('double_quoted_string',
        'single_quoted_string')
-    def string(self, p):
+    def string(self, p: T_StringProduction) -> Union[SingleQuotedString, DoubleQuotedString]:
         return p[0]
 
     @_('TRUE')
-    def boolean(self, p):
+    def boolean(self, p: Any) -> BooleanLiteral:
         return BooleanLiteral(True)
 
     @_('FALSE')  # type: ignore[no-redef]
-    def boolean(self, p):
+    def boolean(self, p: Any) -> BooleanLiteral:
         return BooleanLiteral(False)
 
     @_('NULL')
-    def null(self, p):
+    def null(self, p: Any) -> NullLiteral:
         return NullLiteral()
 
     @_('string',  # type: ignore[no-redef]
@@ -390,20 +489,20 @@ class JSONParser(Parser):
        'boolean',
        'null',
        'number',)
-    def value(self, p):
+    def value(self, p: T_ValueProduction) -> Union[DoubleQuotedString, SingleQuotedString, JSONObject, JSONArray, BooleanLiteral, NullLiteral, Infinity, Integer, Float, NaN]:
         node = p[0]
         return node
 
     @_('UNTERMINATED_SINGLE_QUOTE_STRING',  # type: ignore[no-redef]
        'UNTERMINATED_DOUBLE_QUOTE_STRING')
-    def string(self, p):
+    def string(self, p: T_StringTokenProduction) -> Union[SingleQuotedString, DoubleQuotedString]:
         self.error(p._slice[0])
         raw = p[0]
         if raw.startswith('"'):
             return DoubleQuotedString(raw[1:], raw_value=raw)
         return SingleQuotedString(raw[1:], raw_value=raw)
 
-    def error(self, token):
+    def error(self, token: Optional[JSON5Token]) -> Optional[JSON5Token]:
         if token:
             if self.expecting:
                 expected = self.expecting[-1]
@@ -414,7 +513,7 @@ class JSONParser(Parser):
 
             self.errors.append(JSON5DecodeError(message, token))
             try:
-                return next(self.tokens)
+                return next(self.tokens)  # type: ignore[call-overload]
             except StopIteration:
                 # EOF
                 class tok:
@@ -423,7 +522,7 @@ class JSONParser(Parser):
                     lineno=None
                     index=None
                     end=None
-                return JSON5Token(tok(), None)
+                return JSON5Token(tok(), None)  # type: ignore[arg-type]
         elif self.last_token:
             doc = self.last_token.doc
             pos = len(doc)
@@ -439,15 +538,15 @@ class JSONParser(Parser):
             #  Empty file
             self.errors.append(JSON5DecodeError('Expecting value. Received unexpected EOF', None))
 
-    def _token_gen(self, tokens):
+    def _token_gen(self, tokens: typing.Iterable[JSON5Token]) -> typing.Generator[JSON5Token, None, None]:
         for tok in tokens:
             self.last_token = tok
             self.seen_tokens.append(tok)
             yield tok
 
-    def parse(self, tokens):
+    def parse(self, tokens: typing.Iterable[JSON5Token]) -> JSONText:
         tokens = self._token_gen(tokens)
-        model = super().parse(tokens)
+        model: JSONText = super().parse(tokens)
         if self.errors:
             if len(self.errors) > 1:
                 primary_error = self.errors[0]
@@ -470,12 +569,12 @@ class JSONParser(Parser):
         return model
 
 
-def parse_tokens(raw_tokens):
+def parse_tokens(raw_tokens: typing.Iterable[JSON5Token]) -> JSONText:
     parser = JSONParser()
     return parser.parse(raw_tokens)
 
 
-def parse_source(text):
+def parse_source(text: str) -> JSONText:
     tokens = tokenize(text)
     model = parse_tokens(tokens)
     return model

--- a/json5/parser.py
+++ b/json5/parser.py
@@ -2,8 +2,8 @@ import regex as re
 
 import sys
 
-from sly import Parser
-from sly.yacc import SlyLogger
+from sly import Parser  # type: ignore
+from sly.yacc import SlyLogger  # type: ignore
 from json5.tokenizer import JSONLexer, tokenize, JSON5Token
 from json5.model import *
 from json5.utils import JSON5DecodeError
@@ -121,7 +121,7 @@ class JSONParser(Parser):
         return BlockComment(p[0], tok=p._slice[0])
 
 
-    @_('LINE_COMMENT')
+    @_('LINE_COMMENT') # type: ignore[no-redef]
     def comment(self, p):
         return LineComment(p[0], tok=p._slice[0])
 
@@ -268,11 +268,11 @@ class JSONParser(Parser):
     def number(self, p):
         return Integer(p[0], tok=p._slice[0])
 
-    @_('FLOAT')
+    @_('FLOAT')  # type: ignore[no-redef]
     def number(self, p):
         return Float(p[0], tok=p._slice[0])
 
-    @_('OCTAL')
+    @_('OCTAL')  # type: ignore[no-redef]
     def number(self, p):
         self.errors.append(JSON5DecodeError("Invalid integer literal. Octals are not allowed", p._slice[0]))
         raw_value = p[0]
@@ -283,11 +283,11 @@ class JSONParser(Parser):
 
 
 
-    @_('INFINITY')
+    @_('INFINITY')  # type: ignore[no-redef]
     def number(self, p):
         return Infinity()
 
-    @_('NAN')
+    @_('NAN')  # type: ignore[no-redef]
     def number(self, p):
         return NaN()
 
@@ -298,18 +298,18 @@ class JSONParser(Parser):
         node = UnaryOp(op='-', value=p.number)
         return node
 
-    @_('PLUS number')
+    @_('PLUS number')  # type: ignore[no-redef]
     def value(self, p):
         node = UnaryOp(op='+', value=p.number)
         return node
 
-    @_('INTEGER EXPONENT',
+    @_('INTEGER EXPONENT',  # type: ignore[no-redef]
        'FLOAT EXPONENT')
     def number(self, p):
         exp_notation = p[1][0]  # e or E
         return Float(p[0]+p[1], exp_notation=exp_notation)
 
-    @_('HEXADECIMAL')
+    @_('HEXADECIMAL')  # type: ignore[no-redef]
     def number(self, p):
         return Integer(p[0], is_hex=True)
 
@@ -376,7 +376,7 @@ class JSONParser(Parser):
     def boolean(self, p):
         return BooleanLiteral(True)
 
-    @_('FALSE')
+    @_('FALSE')  # type: ignore[no-redef]
     def boolean(self, p):
         return BooleanLiteral(False)
 
@@ -384,7 +384,7 @@ class JSONParser(Parser):
     def null(self, p):
         return NullLiteral()
 
-    @_('string',
+    @_('string',  # type: ignore[no-redef]
        'json_object',
        'json_array',
        'boolean',
@@ -394,7 +394,7 @@ class JSONParser(Parser):
         node = p[0]
         return node
 
-    @_('UNTERMINATED_SINGLE_QUOTE_STRING',
+    @_('UNTERMINATED_SINGLE_QUOTE_STRING',  # type: ignore[no-redef]
        'UNTERMINATED_DOUBLE_QUOTE_STRING')
     def string(self, p):
         self.error(p._slice[0])

--- a/json5/tokenizer.py
+++ b/json5/tokenizer.py
@@ -1,21 +1,26 @@
+from __future__ import annotations
+
+import logging
 import typing
-from typing import Generator, NoReturn
+from typing import Generator
+from typing import NoReturn
 
 import regex as re
-import sys
 from sly import Lexer  # type: ignore
 from sly.lex import Token  # type: ignore
+
 from json5.utils import JSON5DecodeError
-import logging
 
 logger = logging.getLogger(__name__)
 # logger.addHandler(logging.StreamHandler(stream=sys.stderr))
 # logger.setLevel(level=logging.DEBUG)
 
+
 class JSON5Token(Token):  # type: ignore[misc]
     '''
     Representation of a single token.
     '''
+
     def __init__(self, tok: Token, doc: str):
         self.type = tok.type
         self.value = tok.value
@@ -23,37 +28,49 @@ class JSON5Token(Token):  # type: ignore[misc]
         self.index = tok.index
         self.doc = doc
         self.end = getattr(tok, 'end', None)
+
     __slots__ = ('type', 'value', 'lineno', 'index', 'doc', 'end')
 
     def __repr__(self) -> str:
         return f'JSON5Token(type={self.type!r}, value={self.value!r}, lineno={self.lineno}, index={self.index}, end={self.end})'
 
+
 T_CallArg = typing.TypeVar('T_CallArg')
 _: typing.Callable[[str], typing.Callable[[T_CallArg], T_CallArg]]
+
 
 class JSONLexer(Lexer):  # type: ignore[misc]
     regex_module = re
     reflags = re.DOTALL
-    tokens = {LBRACE, RBRACE,
-              LBRACKET, RBRACKET,
-              DOUBLE_QUOTE_STRING, SINGLE_QUOTE_STRING,
-              UNTERMINATED_DOUBLE_QUOTE_STRING,
-              UNTERMINATED_SINGLE_QUOTE_STRING,
-              NAME,
-              COMMA,
-              BLOCK_COMMENT,
-              LINE_COMMENT,
-              WHITESPACE,
-              TRUE, FALSE, NULL,
-              COLON,
-
-              # Numbers
-              PLUS, MINUS,
-              FLOAT, INTEGER,
-              INFINITY, NAN, EXPONENT,
-              HEXADECIMAL,
-              OCTAL  # Not allowed, but we capture as a token to raise error later
-              }
+    tokens = {
+        LBRACE,
+        RBRACE,
+        LBRACKET,
+        RBRACKET,
+        DOUBLE_QUOTE_STRING,
+        SINGLE_QUOTE_STRING,
+        UNTERMINATED_DOUBLE_QUOTE_STRING,
+        UNTERMINATED_SINGLE_QUOTE_STRING,
+        NAME,
+        COMMA,
+        BLOCK_COMMENT,
+        LINE_COMMENT,
+        WHITESPACE,
+        TRUE,
+        FALSE,
+        NULL,
+        COLON,
+        # Numbers
+        PLUS,
+        MINUS,
+        FLOAT,
+        INTEGER,
+        INFINITY,
+        NAN,
+        EXPONENT,
+        HEXADECIMAL,
+        OCTAL,  # Not allowed, but we capture as a token to raise error later
+    }
 
     def tokenize(self, text: str, lineno: int = 1, index: int = 0) -> Generator[JSON5Token, None, None]:
         for tok in super().tokenize(text, lineno, index):
@@ -71,6 +88,7 @@ class JSONLexer(Lexer):  # type: ignore[misc]
     SINGLE_QUOTE_STRING = r"'(?:[^'\\]|\\.)*'"
 
     LINE_COMMENT = r"//[^\n]*"
+
     @_(r'/\*((.|\n))*?\*/')
     def BLOCK_COMMENT(self, tok: JSON5Token) -> JSON5Token:
         self.lineno += tok.value.count('\n')
@@ -86,7 +104,7 @@ class JSONLexer(Lexer):  # type: ignore[misc]
     EXPONENT = r"(e|E)(\-|\+)?\d+"
     HEXADECIMAL = r'0(x|X)[0-9a-fA-F]+'
     OCTAL = r'(0\d+|0o\d+)'
-    FLOAT = r'(\d+\.\d*)|(\d*\.\d+)'      # 23.45
+    FLOAT = r'(\d+\.\d*)|(\d*\.\d+)'  # 23.45
     INTEGER = r'\d+'
     NAME = r'[\w_\$\\]([\w_\d\$\\\p{Pc}\p{Mn}\p{Mc}\u200C\u200D])*'
 
@@ -101,6 +119,7 @@ class JSONLexer(Lexer):  # type: ignore[misc]
 
     def error(self, t: JSON5Token) -> NoReturn:
         raise JSON5DecodeError(f'Illegal character {t.value[0]!r} at index {self.index}', None)
+
 
 def tokenize(text: str) -> Generator[JSON5Token, None, None]:
     lexer = JSONLexer()

--- a/json5/tokenizer.py
+++ b/json5/tokenizer.py
@@ -1,7 +1,7 @@
 import regex as re
 import sys
-from sly import Lexer
-from sly.lex import Token
+from sly import Lexer  # type: ignore
+from sly.lex import Token  # type: ignore
 from json5.utils import JSON5DecodeError
 import logging
 
@@ -84,11 +84,11 @@ class JSONLexer(Lexer):
     INTEGER = r'\d+'
     NAME = r'[\w_\$\\]([\w_\d\$\\\p{Pc}\p{Mn}\p{Mc}\u200C\u200D])*'
 
-    NAME['true'] = TRUE
-    NAME['false'] = FALSE
-    NAME['null'] = NULL
-    NAME['Infinity'] = INFINITY
-    NAME['NaN'] = NAN
+    NAME['true'] = TRUE  # type: ignore[index]
+    NAME['false'] = FALSE  # type: ignore[index]
+    NAME['null'] = NULL  # type: ignore[index]
+    NAME['Infinity'] = INFINITY  # type: ignore[index]
+    NAME['NaN'] = NAN  # type: ignore[index]
 
     UNTERMINATED_DOUBLE_QUOTE_STRING = r'"(?:[^"\\]|\\.)*'
     UNTERMINATED_SINGLE_QUOTE_STRING = r"'(?:[^'\\]|\\.)*"

--- a/json5/utils.py
+++ b/json5/utils.py
@@ -16,12 +16,14 @@ except ImportError:
         update_wrapper(wrapper, func)
         return wrapper
 
+__all__ = ['singledispatchmethod', 'JSON5DecodeError']
+
 if typing.TYPE_CHECKING:
     from .tokenizer import JSON5Token
 
 
 class JSON5DecodeError(JSONDecodeError):
-    def __init__(self, msg: str, token: JSON5Token):
+    def __init__(self, msg: str, token: typing.Optional[JSON5Token]):
         lineno = getattr(token, 'lineno', 0)
         index = getattr(token, 'index', 0)
         doc = getattr(token, 'doc', None)
@@ -35,5 +37,5 @@ class JSON5DecodeError(JSONDecodeError):
             self.msg = msg
             self.lineno = lineno
 
-    def __reduce__(self) -> Tuple[Type[JSON5DecodeError], Tuple[str, JSON5Token]]:
+    def __reduce__(self) -> Tuple[Type[JSON5DecodeError], Tuple[str, typing.Optional[JSON5Token]]]:
         return self.__class__, (self.msg, self.token)

--- a/json5/utils.py
+++ b/json5/utils.py
@@ -1,21 +1,27 @@
+from __future__ import annotations
+import typing
+from typing import Callable, Any, Tuple, Type
 from functools import singledispatch, update_wrapper
 from json import JSONDecodeError
 try:
     from functools import singledispatchmethod
 except ImportError:
-    def singledispatchmethod(func):
+    def singledispatchmethod(func: Callable[..., Any]) -> Any:  # type: ignore[no-redef]
         dispatcher = singledispatch(func)
 
-        def wrapper(*args, **kwargs):
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
             return dispatcher.dispatch(args[1].__class__)(*args, **kwargs)
 
-        wrapper.register = dispatcher.register
+        wrapper.register = dispatcher.register  # type: ignore[attr-defined]
         update_wrapper(wrapper, func)
         return wrapper
 
+if typing.TYPE_CHECKING:
+    from .tokenizer import JSON5Token
+
 
 class JSON5DecodeError(JSONDecodeError):
-    def __init__(self, msg, token):
+    def __init__(self, msg: str, token: JSON5Token):
         lineno = getattr(token, 'lineno', 0)
         index = getattr(token, 'index', 0)
         doc = getattr(token, 'doc', None)
@@ -29,5 +35,5 @@ class JSON5DecodeError(JSONDecodeError):
             self.msg = msg
             self.lineno = lineno
 
-    def __reduce__(self):
+    def __reduce__(self) -> Tuple[Type[JSON5DecodeError], Tuple[str, JSON5Token]]:
         return self.__class__, (self.msg, self.token)

--- a/json5/utils.py
+++ b/json5/utils.py
@@ -1,11 +1,18 @@
 from __future__ import annotations
+
 import typing
-from typing import Callable, Any, Tuple, Type
-from functools import singledispatch, update_wrapper
+from functools import singledispatch
+from functools import update_wrapper
 from json import JSONDecodeError
+from typing import Any
+from typing import Callable
+from typing import Tuple
+from typing import Type
+
 try:
     from functools import singledispatchmethod
 except ImportError:
+
     def singledispatchmethod(func: Callable[..., Any]) -> Any:  # type: ignore[no-redef]
         dispatcher = singledispatch(func)
 
@@ -15,6 +22,7 @@ except ImportError:
         wrapper.register = dispatcher.register  # type: ignore[attr-defined]
         update_wrapper(wrapper, func)
         return wrapper
+
 
 __all__ = ['singledispatchmethod', 'JSON5DecodeError']
 

--- a/json5/utils.py
+++ b/json5/utils.py
@@ -6,8 +6,6 @@ from functools import update_wrapper
 from json import JSONDecodeError
 from typing import Any
 from typing import Callable
-from typing import Tuple
-from typing import Type
 
 try:
     from functools import singledispatchmethod
@@ -31,7 +29,7 @@ if typing.TYPE_CHECKING:
 
 
 class JSON5DecodeError(JSONDecodeError):
-    def __init__(self, msg: str, token: typing.Optional[JSON5Token]):
+    def __init__(self, msg: str, token: JSON5Token | None):
         lineno = getattr(token, 'lineno', 0)
         index = getattr(token, 'index', 0)
         doc = getattr(token, 'doc', None)
@@ -45,5 +43,5 @@ class JSON5DecodeError(JSONDecodeError):
             self.msg = msg
             self.lineno = lineno
 
-    def __reduce__(self) -> Tuple[Type[JSON5DecodeError], Tuple[str, typing.Optional[JSON5Token]]]:
+    def __reduce__(self) -> tuple[type[JSON5DecodeError], tuple[str, JSON5Token | None]]:
         return self.__class__, (self.msg, self.token)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,4 @@ regex
 pytest
 mypy
 coverage
+types-regex

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,5 @@
+sly
+regex
+pytest
+mypy
+coverage

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,30 @@
 [metadata]
+name = json-five
+version = 1.0.0rc1
+url = https://github.com/spyoungtech/json-five
+license = Apache
+author = Spencer Phillip Young
+author_email = spencer.young@spyoung.com
+description = A JSON5 parser that, among other features, supports round-trip preservation of comments
+long_description = file: README.md
+long_description_content_type = text/markdown
+classifiers =
+    License :: OSI Approved :: Apache Software License
+    Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+
 license_files = LICENSE
+
+[options]
+packages = json5
+python_requires = >=3.8.0
+install_requires =
+    sly
+    regex
+
+[options.package_data]
+json5 =
+    py.typed

--- a/setup.py
+++ b/setup.py
@@ -1,2 +1,3 @@
 from setuptools import setup
+
 setup()

--- a/setup.py
+++ b/setup.py
@@ -1,26 +1,2 @@
 from setuptools import setup
-from io import open
-
-with open('README.md', encoding='utf-8') as f:
-    long_description = f.read()
-
-setup(
-    name='json-five',
-    version='0.8.0',
-    packages=['json5'],
-    url='https://github.com/spyoungtech/json-five',
-    license='Apache',
-    author='Spencer Phillip Young',
-    author_email='spencer.young@spyoung.com',
-    description='A JSON5 parser that, among other features, supports round-trip preservation of comments',
-    long_description=long_description,
-    long_description_content_type='text/markdown',
-    install_requires=['sly', 'regex'],
-    classifiers=[
-        'License :: OSI Approved :: Apache Software License',
-        'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-    ]
-)
+setup()

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -20,7 +20,7 @@ def test_loading_comment_raises_runtime_error_default_loader():
 
 
 def test_loading_unknown_node_raises_error():
-    class Foo(object):
+    class Foo:
         ...
 
     f = Foo()
@@ -29,7 +29,7 @@ def test_loading_unknown_node_raises_error():
 
 
 def test_dumping_unknown_node_raises_error():
-    class Foo(object):
+    class Foo:
         ...
 
     f = Foo()
@@ -142,17 +142,17 @@ def test_illegal_line_terminator_error_message(json_string):
         loads(json_string)
 
     exc_message = str(exc_info.value)
-    exc_lineno_match = re.search('line (\d+)', exc_message)
+    exc_lineno_match = re.search(r'line (\d+)', exc_message)
     if exc_lineno_match:
         exc_lineno = int(exc_lineno_match.groups()[0])
     else:
         exc_lineno = None
-    exc_col_match = re.search('column (\d+)', exc_message)
+    exc_col_match = re.search(r'column (\d+)', exc_message)
     if exc_col_match:
         exc_col = int(exc_col_match.groups()[0])
     else:
         exc_col = None
-    exc_index_match = re.search('char (\d+)', exc_message)
+    exc_index_match = re.search(r'char (\d+)', exc_message)
     if exc_index_match:
         exc_index = int(exc_index_match.groups()[0])
     else:
@@ -196,7 +196,7 @@ def test_object_multiple_trailing_commas_raises_error():
 
 def test_expecting_rbracket():
     json_string = """[true, false"""
-    with pytest.raises(JSON5DecodeError) as exc_info:
+    with pytest.raises(JSON5DecodeError):
         loads(json_string)
 
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,9 +1,15 @@
-from json5.loader import loads, ModelLoader, DefaultLoader
-from json5.dumper import DefaultDumper, ModelDumper, modelize
-from json5.model import LineComment, Integer
-import pytest
 import re
 
+import pytest
+
+from json5.dumper import DefaultDumper
+from json5.dumper import ModelDumper
+from json5.dumper import modelize
+from json5.loader import DefaultLoader
+from json5.loader import loads
+from json5.loader import ModelLoader
+from json5.model import Integer
+from json5.model import LineComment
 from json5.utils import JSON5DecodeError
 
 
@@ -16,6 +22,7 @@ def test_loading_comment_raises_runtime_error_default_loader():
 def test_loading_unknown_node_raises_error():
     class Foo(object):
         ...
+
     f = Foo()
     with pytest.raises(NotImplementedError):
         DefaultLoader().load(f)
@@ -24,13 +31,16 @@ def test_loading_unknown_node_raises_error():
 def test_dumping_unknown_node_raises_error():
     class Foo(object):
         ...
+
     f = Foo()
     with pytest.raises(NotImplementedError):
         DefaultDumper().dump(f)
 
+
 def test_known_type_in_wsc_raises_error():
     class Foo:
         ...
+
     f = Foo()
     model = loads('{foo: "bar"}', loader=ModelLoader())
     model.value.key_value_pairs[0].key.wsc_before.append(f)
@@ -45,16 +55,20 @@ def test_known_type_in_wsc_raises_error():
 def test_modelizing_unknown_object_raises_error():
     class Foo:
         ...
+
     f = Foo()
     with pytest.raises(NotImplementedError):
         modelize(f)
 
+
 def test_model_dumper_raises_error_for_unknown_node():
     class Foo:
         ...
+
     f = Foo()
     with pytest.raises(NotImplementedError):
         ModelDumper().dump(f)
+
 
 def test_multiple_errors_all_surface_at_once():
     json_string = """[\n"foo",\n"bar"\n"baz",\n"bacon"\n"eggs"]"""
@@ -89,24 +103,29 @@ def test_backslash_x_without_two_hexadecimals_raises_error():
         loads(r"'\x1'")
     assert "'\\x' MUST be followed by two hexadecimal digits" in str(exc_info.value)
 
+
 def test_null_escape_may_not_be_followed_by_decimal_digit():
     with pytest.raises(JSON5DecodeError) as exc_info:
         loads(r"'\01'")
     assert "'\\0' MUST NOT be followed by a decimal digit" in str(exc_info.value)
+
 
 def test_backslash_x_without_two_hexadecimals_raises_error_but_for_double_quotes():
     with pytest.raises(JSON5DecodeError) as exc_info:
         loads(r'"\x1"')
     assert "'\\x' MUST be followed by two hexadecimal digits" in str(exc_info.value)
 
+
 def test_null_escape_may_not_be_followed_by_decimal_digit_but_for_double_quotes():
     with pytest.raises(JSON5DecodeError) as exc_info:
         loads(r'"\01"')
     assert "'\\0' MUST NOT be followed by a decimal digit" in str(exc_info.value)
 
+
 def test_integer_octal_hex_mutually_exclusive():
     with pytest.raises(ValueError):
         Integer(raw_value='0o0', is_hex=True, is_octal=True)
+
 
 def test_invalid_identifier_via_escape_sequence():
     json_string = """{\\u005Cfoo: 1}"""
@@ -114,9 +133,11 @@ def test_invalid_identifier_via_escape_sequence():
         loads(json_string)
     assert "Invalid identifier name" in str(exc_info.value)
 
-@pytest.mark.parametrize('json_string', [""""foo \\\nbar baz \\\nbacon \neggs\"""", """'foo \\\nbar baz \\\nbacon \neggs'"""])
-def test_illegal_line_terminator_error_message(json_string):
 
+@pytest.mark.parametrize(
+    'json_string', [""""foo \\\nbar baz \\\nbacon \neggs\"""", """'foo \\\nbar baz \\\nbacon \neggs'"""]
+)
+def test_illegal_line_terminator_error_message(json_string):
     with pytest.raises(JSON5DecodeError) as exc_info:
         loads(json_string)
 
@@ -138,6 +159,7 @@ def test_illegal_line_terminator_error_message(json_string):
         exc_index = None
     assert (3, 7, 23) == (exc_lineno, exc_col, exc_index)
 
+
 def test_octals_are_rejected_by_default():
     json_string = "0o123"
     with pytest.raises(JSON5DecodeError) as exc_info:
@@ -150,6 +172,7 @@ def test_malformed_octals_result_in_additional_error():
     with pytest.raises(JSON5DecodeError) as exc_info:
         loads(json_string)
     assert "Invalid octal format" in str(exc_info.value)
+
 
 @pytest.mark.parametrize('json_string', ['{foo: "bar}', "{foo: 'bar}"])
 def test_unterminated_string(json_string):
@@ -164,17 +187,17 @@ def test_array_multiple_trailing_commas_raises_error():
         loads('["foo",,]')
     assert "multiple trailing commas" in str(exc_info.value)
 
+
 def test_object_multiple_trailing_commas_raises_error():
     with pytest.raises(JSON5DecodeError) as exc_info:
         loads('{foo: "bar",,}')
     assert "multiple trailing commas" in str(exc_info.value)
 
+
 def test_expecting_rbracket():
     json_string = """[true, false"""
     with pytest.raises(JSON5DecodeError) as exc_info:
         loads(json_string)
-
-
 
 
 def test_array_expecting_value_or_bracket():
@@ -183,11 +206,13 @@ def test_array_expecting_value_or_bracket():
         loads(json_string)
     assert 'RBRACKET or value' in str(exc_info.value)
 
+
 def test_array_expecting_comma_or_bracket():
     json_string = '[true'
     with pytest.raises(JSON5DecodeError) as exc_info:
         loads(json_string)
     assert "RBRACKET or COMMA" in str(exc_info.value)
+
 
 def test_array_expecting_value_or_bracket_trailing_comma():
     json_string = '[true,'
@@ -196,17 +221,20 @@ def test_array_expecting_value_or_bracket_trailing_comma():
 
     assert 'RBRACKET or value' in str(exc_info.value)
 
+
 def test_object_expecting_value_or_brace():
     json_string = '{'
     with pytest.raises(JSON5DecodeError) as exc_info:
         loads(json_string)
     assert 'RBRACE or key' in str(exc_info.value)
 
+
 def test_object_expecting_comma_or_brace():
     json_string = '{foo: true'
     with pytest.raises(JSON5DecodeError) as exc_info:
         loads(json_string)
     assert "COMMA or RBRACE" in str(exc_info.value)
+
 
 def test_object_expecting_key_or_brace_trailing_comma():
     json_string = '{foo: true,'

--- a/tests/test_json5_dump.py
+++ b/tests/test_json5_dump.py
@@ -4,7 +4,6 @@ from io import StringIO
 
 from json5 import dump
 from json5 import dumps
-from json5 import loads
 from json5.dumper import ModelDumper
 from json5.model import Integer
 from json5.model import UnaryOp

--- a/tests/test_json5_dump.py
+++ b/tests/test_json5_dump.py
@@ -1,9 +1,13 @@
-from json5 import dumps, loads, dump
-from json5.dumper import ModelDumper
-from json5.model import UnaryOp, Integer
 import json
 import math
 from io import StringIO
+
+from json5 import dump
+from json5 import dumps
+from json5 import loads
+from json5.dumper import ModelDumper
+from json5.model import Integer
+from json5.model import UnaryOp
 
 
 def test_json_dump_empty_object():
@@ -38,6 +42,7 @@ def test_dump_indent_same_as_json():
     }
     assert dumps(d, indent=4) == json.dumps(d, indent=4)
 
+
 def test_dump_boolean():
     d = {'foo': True}
     assert dumps(d) == json.dumps(d)
@@ -52,8 +57,10 @@ def test_dump_none():
     d = {'foo': None}
     assert dumps(d) == json.dumps(d)
 
+
 def test_dump_unary_plus():
     assert dumps(UnaryOp('+', Integer('1')), dumper=ModelDumper()) == '+1'
+
 
 def test_dump_file():
     f = StringIO()

--- a/tests/test_json5_load.py
+++ b/tests/test_json5_load.py
@@ -2,12 +2,10 @@ import math
 from io import StringIO
 
 import pytest
-from sly.lex import LexError
 
 from json5.loader import JsonIdentifier
 from json5.loader import load
 from json5.loader import loads
-from json5.utils import JSON5DecodeError
 
 
 def test_object_string_key_value_pair():

--- a/tests/test_json5_load.py
+++ b/tests/test_json5_load.py
@@ -1,10 +1,12 @@
 import math
-
-import pytest
-from json5.loader import loads, JsonIdentifier, load
-from sly.lex import LexError
 from io import StringIO
 
+import pytest
+from sly.lex import LexError
+
+from json5.loader import JsonIdentifier
+from json5.loader import load
+from json5.loader import loads
 from json5.utils import JSON5DecodeError
 
 
@@ -56,6 +58,7 @@ def test_object_with_multiline_comment():
     }"""
     assert loads(json_string) == {"foo": "bar"}
 
+
 def test_array_load_with_line_comment():
     json_string = """[ // line comment
     "foo", "bar"
@@ -68,7 +71,6 @@ def test_array_with_multiline_comment():
     */ "foo", "bar"
     ]"""
     assert loads(json_string) == ["foo", "bar"]
-
 
 
 def test_nested_object():
@@ -198,7 +200,14 @@ def test_empty_array():
 
 @pytest.mark.parametrize(
     "json_string",
-    ['{"foo": "bar", "bar" "baz"', '["foo" "bar"]', "[,]", "{,}", "!", '{"foo": "bar" "bacon": "eggs"}',],
+    [
+        '{"foo": "bar", "bar" "baz"',
+        '["foo" "bar"]',
+        "[,]",
+        "{,}",
+        "!",
+        '{"foo": "bar" "bacon": "eggs"}',
+    ],
 )
 def test_invalid_json(json_string):
     with pytest.raises(Exception):
@@ -237,17 +246,21 @@ def test_boolean_load_true():
     json_string = """{foo: true}"""
     assert loads(json_string) == {'foo': True}
 
+
 def test_boolean_load_false():
     json_string = """{foo: false}"""
     assert loads(json_string) == {'foo': False}
+
 
 def test_null_load():
     json_string = """{foo: null}"""
     assert loads(json_string) == {'foo': None}
 
+
 def test_unary_plus_load():
     json_string = """{foo: +12 }"""
     assert loads(json_string) == {'foo': 12}
+
 
 def test_load_from_file():
     f = StringIO('{foo: 123}')
@@ -263,17 +276,21 @@ def test_load_empty_object_wtih_whitespace():
     json_string = "[   ]"
     assert loads(json_string) == []
 
+
 def test_load_empty_object_with_comments():
     json_string = "{ // foo \n}"
     assert loads(json_string) == {}
+
 
 def test_load_empty_array_with_comments():
     json_string = "[ // foo \n]"
     assert loads(json_string) == []
 
+
 def test_load_array_with_comment_before_additional_element():
     json_string = "['foo',/* comment */ 'bar', // foo\n'baz']"
     assert loads(json_string) == ['foo', 'bar', 'baz']
+
 
 def test_load_object_with_additional_comments():
     json_string = """{
@@ -289,8 +306,10 @@ def test_load_latin_escape():
     json_string = r'"\x5C"'
     assert loads(json_string) == '\\'
 
+
 def test_latin_escape_backslash_is_not_real_backslack():
     assert loads("""'\\x5C01'""") == "\\01"
+
 
 def test_escape_unicode():
     json_string = """
@@ -299,6 +318,7 @@ def test_escape_unicode():
     }
     """
     assert loads(json_string) == {"sig\u03A3ma": "\u03A3 is the sum of all things"}
+
 
 def test_load_identifier_with_connector_punctuation():
     json_string = """{foo⁀bar: 1}"""

--- a/tests/test_json5_official_tests.py
+++ b/tests/test_json5_official_tests.py
@@ -1,7 +1,6 @@
 import os
 import re
 from collections import namedtuple
-from io import open
 
 import pytest
 
@@ -57,7 +56,7 @@ def test_official_error_specs(input_file, expected):
     if not os.path.exists(tests_path):
         pytest.mark.skip("Tests repo was not present in expected location. Skipping.")
         return
-    with pytest.raises(JSON5DecodeError) as exc_info:
+    with pytest.raises(JSON5DecodeError):
         load(open(input_file, encoding='utf-8'))
 
 
@@ -81,19 +80,19 @@ def test_official_error_specs(input_file, expected):
     at = errorspec['at']
     lineno = errorspec['lineNumber']
     col = errorspec['columnNumber']
-    msg = errorspec['message']
+    # msg = errorspec['message']
     exc_message = str(exc_info.value)
-    exc_lineno_match = re.search('line (\d+)', exc_message)
+    exc_lineno_match = re.search(r'line (\d+)', exc_message)
     if exc_lineno_match:
         exc_lineno = int(exc_lineno_match.groups()[0])
     else:
         exc_lineno = None
-    exc_col_match = re.search('column (\d+)', exc_message)
+    exc_col_match = re.search(r'column (\d+)', exc_message)
     if exc_col_match:
         exc_col = int(exc_col_match.groups()[0])
     else:
         exc_col = None
-    exc_index_match = re.search('char (\d+)', exc_message)
+    exc_index_match = re.search(r'char (\d+)', exc_message)
     if exc_index_match:
         exc_index = int(exc_index_match.groups()[0])
     else:

--- a/tests/test_json5_official_tests.py
+++ b/tests/test_json5_official_tests.py
@@ -1,19 +1,23 @@
-from collections import namedtuple
-
-from json5 import loads, load, JSON5DecodeError, dumps
-from json5.loader import ModelLoader
-from json5.dumper import ModelDumper
 import os
 import re
-import pytest
+from collections import namedtuple
 from io import open
+
+import pytest
+
+from json5 import dumps
+from json5 import JSON5DecodeError
+from json5 import load
+from json5 import loads
+from json5.dumper import ModelDumper
+from json5.loader import ModelLoader
 
 tests_path = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), '../json5-tests'))
 
 error_specs = []
 specs = []
 
-for root,dirs,files in os.walk(tests_path):
+for root, dirs, files in os.walk(tests_path):
     for f in files:
         if f.endswith('.json5') or f.endswith('.json'):
             specs.append(os.path.join(root, f))
@@ -21,12 +25,14 @@ for root,dirs,files in os.walk(tests_path):
             error_spec = f.replace('.txt', '.errorSpec').replace('.js', '.errorSpec')
             error_specs.append((os.path.join(root, f), os.path.join(root, error_spec)))
 
+
 @pytest.mark.parametrize('fp', specs)
 def test_official_files(fp):
     if not os.path.exists(tests_path):
         pytest.mark.skip("Tests repo was not present in expected location. Skipping.")
         return
     load(open(fp, encoding='utf-8'))
+
 
 @pytest.mark.parametrize('fp', specs)
 def test_official_files_rt_dumps_no_error(fp):
@@ -36,6 +42,7 @@ def test_official_files_rt_dumps_no_error(fp):
         json_string = f.read()
     dumps(loads(json_string))
 
+
 @pytest.mark.parametrize('fp', specs)
 def test_official_files_rt_model(fp):
     if not os.path.exists(tests_path):
@@ -44,6 +51,7 @@ def test_official_files_rt_model(fp):
         json_string = f.read()
     assert dumps(loads(json_string, loader=ModelLoader()), dumper=ModelDumper()) == json_string
 
+
 @pytest.mark.parametrize(('input_file', 'expected'), error_specs)
 def test_official_error_specs(input_file, expected):
     if not os.path.exists(tests_path):
@@ -51,6 +59,7 @@ def test_official_error_specs(input_file, expected):
         return
     with pytest.raises(JSON5DecodeError) as exc_info:
         load(open(input_file, encoding='utf-8'))
+
 
 @pytest.mark.parametrize(('input_file', 'expected'), error_specs)
 def test_official_error_specs(input_file, expected):
@@ -89,4 +98,4 @@ def test_official_error_specs(input_file, expected):
         exc_index = int(exc_index_match.groups()[0])
     else:
         exc_index = None
-    assert ErrorInfo(exc_lineno, exc_col, exc_index) == ErrorInfo(lineno, col, at-1), f"{input_file} {exc_message}"
+    assert ErrorInfo(exc_lineno, exc_col, exc_index) == ErrorInfo(lineno, col, at - 1), f"{input_file} {exc_message}"

--- a/tests/test_json_helpers.py
+++ b/tests/test_json_helpers.py
@@ -1,8 +1,11 @@
-from json5.model import Identifier
 from json5.dumper import modelize
+from json5.model import Identifier
+
+
 def test_identifier_can_hash_like_string():
     d = {Identifier('foo', raw_value='foo'): 'bar'}
     assert d['foo'] == 'bar'
+
 
 def test_identifier_equals_like_string():
     assert Identifier('foo', raw_value='foo') == 'foo'
@@ -11,6 +14,7 @@ def test_identifier_equals_like_string():
 def test_repr_does_not_contain_wsc():
     model = modelize({'foo': 'bar'})
     assert 'wsc' not in repr(model)
+
 
 def test_identifier_does_not_need_explicit_raw_value():
     assert Identifier('foo').raw_value == 'foo'

--- a/tests/test_loads_options.py
+++ b/tests/test_loads_options.py
@@ -1,6 +1,7 @@
 import json
-import json5
 from decimal import Decimal
+
+import json5
 
 
 def int_plus_one(int_string):
@@ -21,8 +22,10 @@ def const_to_silly(const_string):
 def true_object_hook(d):
     return {k: True for k in d}
 
+
 def true_object_pair_hook(kvpairs):
-    return {k: True for k,v in kvpairs}
+    return {k: True for k, v in kvpairs}
+
 
 def test_parse_int():
     json_string = """{"foo": 5}"""
@@ -32,25 +35,34 @@ def test_parse_int():
 
 def test_parse_float():
     json_string = """{"foo": 5.0}"""
-    assert json5.loads(json_string, parse_float=float_to_decimal) == json.loads(json_string, parse_float=float_to_decimal)
+    assert json5.loads(json_string, parse_float=float_to_decimal) == json.loads(
+        json_string, parse_float=float_to_decimal
+    )
 
 
 def test_parse_constant_nan():
     json_string = """{"foo": NaN}"""
     assert json5.loads(json_string, parse_constant=const_to_silly) == {'foo': 'Something Silly NaN'}
-    assert json5.loads(json_string, parse_constant=const_to_silly) == json.loads(json_string, parse_constant=const_to_silly)
+    assert json5.loads(json_string, parse_constant=const_to_silly) == json.loads(
+        json_string, parse_constant=const_to_silly
+    )
 
 
 def test_parse_constant_positive_infinity():
     json_string = """{"foo": Infinity}"""
     assert json5.loads(json_string, parse_constant=const_to_silly) == {'foo': 'Something Silly Infinity'}
-    assert json5.loads(json_string, parse_constant=const_to_silly) == json.loads(json_string, parse_constant=const_to_silly)
+    assert json5.loads(json_string, parse_constant=const_to_silly) == json.loads(
+        json_string, parse_constant=const_to_silly
+    )
 
 
 def test_parse_constant_negative_infinity():
     json_string = """{"foo": -Infinity}"""
     assert json5.loads(json_string, parse_constant=const_to_silly) == {'foo': 'Something Silly -Infinity'}
-    assert json5.loads(json_string, parse_constant=const_to_silly) == json.loads(json_string, parse_constant=const_to_silly)
+    assert json5.loads(json_string, parse_constant=const_to_silly) == json.loads(
+        json_string, parse_constant=const_to_silly
+    )
+
 
 def test_object_hook():
     json_string = """{"foo": "bar", "bacon": "eggs"}"""

--- a/tests/test_model_loader_dumper.py
+++ b/tests/test_model_loader_dumper.py
@@ -1,11 +1,7 @@
-import math
-
 import pytest
-from sly.lex import LexError
 
 from json5.dumper import dumps
 from json5.dumper import ModelDumper
-from json5.loader import JsonIdentifier
 from json5.loader import loads
 from json5.loader import ModelLoader
 

--- a/tests/test_model_loader_dumper.py
+++ b/tests/test_model_loader_dumper.py
@@ -1,34 +1,41 @@
 import math
 
 import pytest
-from json5.loader import loads, JsonIdentifier, ModelLoader
 from sly.lex import LexError
-from json5.dumper import dumps, ModelDumper
+
+from json5.dumper import dumps
+from json5.dumper import ModelDumper
+from json5.loader import JsonIdentifier
+from json5.loader import loads
+from json5.loader import ModelLoader
 
 
-@pytest.mark.parametrize('json_string', [
-"""{"foo":"bar"}""",
-"""{"foo": "bar"}""",
-"""{"foo":"bar","bacon":"eggs"}""",
-"""{"foo":  "bar", "bacon" :  "eggs"}""",
-"""["foo","bar","baz"]""",
-"""[ "foo", "bar"  , "baz"   ]""",
-"""{"foo":\n "bar"\n}""",
-"""{"foo": {"bacon": "eggs"}}""",
-"""   {"foo":"bar"}""",
-"""{"foo": "bar"}   """,
-"""{'foo': 'bar'}""",
-"""{"foo": 'bar'}""",
-"""{"foo": "bar",}""",
-"""["foo","bar", "baz",]""",
-"""["foo", "bar", "baz", ]""",
-"""["foo", "bar", "baz"  ,]""",
-"""[["foo"], ["foo","bar"], "baz"]""",
-"""{unquoted: "foo"}""",
-"""{unquoted: "foo"}""",
-"""["foo"]""",
-"""["foo" , ]""",
-])
+@pytest.mark.parametrize(
+    'json_string',
+    [
+        """{"foo":"bar"}""",
+        """{"foo": "bar"}""",
+        """{"foo":"bar","bacon":"eggs"}""",
+        """{"foo":  "bar", "bacon" :  "eggs"}""",
+        """["foo","bar","baz"]""",
+        """[ "foo", "bar"  , "baz"   ]""",
+        """{"foo":\n "bar"\n}""",
+        """{"foo": {"bacon": "eggs"}}""",
+        """   {"foo":"bar"}""",
+        """{"foo": "bar"}   """,
+        """{'foo': 'bar'}""",
+        """{"foo": 'bar'}""",
+        """{"foo": "bar",}""",
+        """["foo","bar", "baz",]""",
+        """["foo", "bar", "baz", ]""",
+        """["foo", "bar", "baz"  ,]""",
+        """[["foo"], ["foo","bar"], "baz"]""",
+        """{unquoted: "foo"}""",
+        """{unquoted: "foo"}""",
+        """["foo"]""",
+        """["foo" , ]""",
+    ],
+)
 def test_round_trip_model_load_dump(json_string):
     assert dumps(loads(json_string, loader=ModelLoader()), dumper=ModelDumper()) == json_string
 
@@ -134,6 +141,7 @@ def test_hexadecimal_load():
     positiveHex: 0xdecaf,
     negativeHex: -0xC0FFEE,}"""
     assert dumps(loads(json_string, loader=ModelLoader()), dumper=ModelDumper()) == json_string
+
 
 def test_load_empty_array_with_whitespace():
     json_string = "{   }"

--- a/tests/test_modelizer.py
+++ b/tests/test_modelizer.py
@@ -1,25 +1,36 @@
-from json5.dumper import modelize, ModelDumper, dumps
-from json5.loader import DefaultLoader, ModelLoader, loads
-import pytest, math
+import math
 
-@pytest.mark.parametrize('obj', [
-    {'foo': 'bar', 'bacon': 'eggs'},
-    ['foo', 'bar', 'baz'],
-    {},
-    [],
-    ['foo'],
-    {'foo':'bar'},
-    "Hello world!",
-    123,
-    1.0,
-    -1.0,
-    -2,
-    math.inf,
-    -math.inf,
-    True,
-    False,
-    None,
-])
+import pytest
+
+from json5.dumper import dumps
+from json5.dumper import ModelDumper
+from json5.dumper import modelize
+from json5.loader import DefaultLoader
+from json5.loader import loads
+from json5.loader import ModelLoader
+
+
+@pytest.mark.parametrize(
+    'obj',
+    [
+        {'foo': 'bar', 'bacon': 'eggs'},
+        ['foo', 'bar', 'baz'],
+        {},
+        [],
+        ['foo'],
+        {'foo': 'bar'},
+        "Hello world!",
+        123,
+        1.0,
+        -1.0,
+        -2,
+        math.inf,
+        -math.inf,
+        True,
+        False,
+        None,
+    ],
+)
 def test_modelize_objects(obj):
     assert loads(dumps(modelize(obj), dumper=ModelDumper())) == obj
 
@@ -27,6 +38,7 @@ def test_modelize_objects(obj):
 def test_modelize_nan():
     obj = math.nan
     assert loads(dumps(modelize(obj), dumper=ModelDumper())) is obj
+
 
 def test_modelize_double_quote_string():
     s = "'"

--- a/tests/test_modelizer.py
+++ b/tests/test_modelizer.py
@@ -5,9 +5,7 @@ import pytest
 from json5.dumper import dumps
 from json5.dumper import ModelDumper
 from json5.dumper import modelize
-from json5.loader import DefaultLoader
 from json5.loader import loads
-from json5.loader import ModelLoader
 
 
 @pytest.mark.parametrize(

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -4,20 +4,20 @@ from json5 import JSON5DecodeError
 from json5 import loads
 
 
-## These tests used to cause the program to hang indefinitely
+# These tests used to cause the program to hang indefinitely
 def test_no_hang():
     json_string = '{"foo": ["foo", [0o11]}, ["baz"]]'
-    with pytest.raises(JSON5DecodeError) as exc_info:
+    with pytest.raises(JSON5DecodeError):
         loads(json_string)
 
 
 def test_no_hang2():
     json_string = '[{foo:]}'
-    with pytest.raises(JSON5DecodeError) as exc_info:
+    with pytest.raises(JSON5DecodeError):
         loads(json_string)
 
 
 def test_no_hang3():
     json_string = '[true, {foo:]false}'
-    with pytest.raises(JSON5DecodeError) as exc_info:
+    with pytest.raises(JSON5DecodeError):
         loads(json_string)

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -1,5 +1,7 @@
 import pytest
-from json5 import loads, JSON5DecodeError
+
+from json5 import JSON5DecodeError
+from json5 import loads
 
 
 ## These tests used to cause the program to hang indefinitely
@@ -8,10 +10,12 @@ def test_no_hang():
     with pytest.raises(JSON5DecodeError) as exc_info:
         loads(json_string)
 
+
 def test_no_hang2():
     json_string = '[{foo:]}'
     with pytest.raises(JSON5DecodeError) as exc_info:
         loads(json_string)
+
 
 def test_no_hang3():
     json_string = '[true, {foo:]false}'

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,10 @@
+[tox]
+envlist = py38,py39,py310,py311
+
+[testenv]
+deps = -rrequirements-dev.txt
+passenv =
+    CI
+    PYTHONUNBUFFERED
+commands =
+    coverage run -m pytest -s -vvv

--- a/tox.ini
+++ b/tox.ini
@@ -8,3 +8,4 @@ passenv =
     PYTHONUNBUFFERED
 commands =
     coverage run -m pytest -s -vvv
+    mypy --strict --disable-error-code name-defined json5


### PR DESCRIPTION
- Adds type hints to the library (PEP 561 compliant)
- Drops support for EOL Python versions 3.6 and 3.7
- `JsonIdentifier` inherits from `str` rather than `UserString`
- added `parse_json5_identifiers` keyword argument to allow users to control how JSON5 Identifiers are parsed
- Adopts setup configuration in `setup.cfg`
