### PR TITLE
Model improvements

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,7 @@ repos:
     -   id: check-yaml
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
+        exclude: ^(tests/.*)
 -   repo: https://github.com/asottile/reorder-python-imports
     rev: v3.10.0
     hooks:
@@ -44,3 +45,4 @@ repos:
         args:
           - "--ignore"
           - "E501,E704,E301,W503,F405,F811,F821,F403,"
+        exclude: ^(tests/.*)

--- a/README.md
+++ b/README.md
@@ -84,46 +84,15 @@ Example: a simple model
 
 ```python
 from json5.loader import loads, ModelLoader
-json_string = """{"foo": "bar"}"""
+json_string = """{foo: "bar"}"""
 model = loads(json_string, loader=ModelLoader())
 ```
-The model object looks something like this:
+The resulting model object looks something like this:
 ```python
 JSONText(
     value=JSONObject(
-        key_value_pairs=[
-            KeyValuePair(
-                key=DoubleQuotedString(
-                    characters="foo",
-                    raw_value='"foo"',
-                    tok=JSON5Token(
-                        type="DOUBLE_QUOTE_STRING",
-                        value='"foo"',
-                        lineno=1,
-                        index=1,
-                        end=None,
-                    ),
-                ),
-                value=DoubleQuotedString(
-                    characters="bar",
-                    raw_value='"bar"',
-                    tok=JSON5Token(
-                        type="DOUBLE_QUOTE_STRING",
-                        value='"bar"',
-                        lineno=1,
-                        index=8,
-                        end=None,
-                    ),
-                ),
-                tok=JSON5Token(
-                    type="DOUBLE_QUOTE_STRING",
-                    value='"foo"',
-                    lineno=1,
-                    index=1,
-                    end=None,
-                ),
-            )
-        ],
+        keys=[Identifier(name="foo", raw_value="foo")],
+        values=[DoubleQuotedString(characters="bar", raw_value='"bar"')],
         trailing_comma=None,
     )
 )
@@ -136,6 +105,26 @@ there is (currently) no validation to ensure your model edits won't result in in
 You may also implement custom loaders and dumpers to control serialization and deserialization. See the [full documentation](https://json-five.readthedocs.io/en/latest/extending.html#custom-loaders-and-dumpers)
 for more information.
 
+## Tokenization
+
+You can also leverage tokenization of JSON5:
+
+```python
+from json5.tokenizer import tokenize
+
+json_string = """{foo: "bar"}"""
+for tok in tokenize(json_string):
+    print(tok.type)
+```
+Output would be:
+```text
+LBRACE
+NAME
+COLON
+WHITESPACE
+DOUBLE_QUOTE_STRING
+RBRACE
+```
 
 # Status
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ For basic loading/dumping, the interface is nearly identical to that of the `jso
 ```python
 import json5
 json_text = """{ // This is a JSON5 comment
-"foo": "bar" /* this is a JSON5 block
+"foo": "bar", /* this is a JSON5 block
 comment that can span lines */
 bacon: "eggs"  // unquoted Identifiers also work
 }

--- a/json5/dumper.py
+++ b/json5/dumper.py
@@ -200,8 +200,9 @@ class ModelDumper:
         self.env.write('{')
         if node.leading_wsc:
             self.process_leading_wsc(node)
-        num_pairs = len(node.key_value_pairs)
-        for index, kvp in enumerate(node.key_value_pairs, start=1):
+        key_value_pairs = node.key_value_pairs
+        num_pairs = len(key_value_pairs)
+        for index, kvp in enumerate(key_value_pairs, start=1):
             self.dump(kvp.key)
             self.env.write(':')
             self.dump(kvp.value)

--- a/json5/dumper.py
+++ b/json5/dumper.py
@@ -9,7 +9,27 @@ from functools import singledispatchmethod
 from typing import Any
 
 from .loader import JsonIdentifier
-from json5.model import *
+from .model import BlockComment
+from .model import BooleanLiteral
+from .model import Comment
+from .model import DoubleQuotedString
+from .model import Float
+from .model import Identifier
+from .model import Infinity
+from .model import Integer
+from .model import JSONArray
+from .model import JSONObject
+from .model import JSONText
+from .model import KeyValuePair
+from .model import LineComment
+from .model import NaN
+from .model import Node
+from .model import NullLiteral
+from .model import SingleQuotedString
+from .model import String
+from .model import TrailingComma
+from .model import UnaryOp
+from .model import Value
 
 
 class Environment:

--- a/json5/dumper.py
+++ b/json5/dumper.py
@@ -5,10 +5,10 @@ import json
 import math
 import typing
 from abc import abstractmethod
+from functools import singledispatchmethod
 from typing import Any
 
 from .loader import JsonIdentifier
-from .utils import singledispatchmethod
 from json5.model import *
 
 

--- a/json5/loader.py
+++ b/json5/loader.py
@@ -7,23 +7,23 @@ from functools import singledispatchmethod
 from typing import Callable
 from typing import Literal
 
-from json5.model import BooleanLiteral
-from json5.model import Comment
-from json5.model import DoubleQuotedString
-from json5.model import Float
-from json5.model import Identifier
-from json5.model import Infinity
-from json5.model import Integer
-from json5.model import JSONArray
-from json5.model import JSONObject
-from json5.model import JSONText
-from json5.model import NaN
-from json5.model import Node
-from json5.model import NullLiteral
-from json5.model import SingleQuotedString
-from json5.model import String
-from json5.model import UnaryOp
-from json5.parser import parse_source
+from .model import BooleanLiteral
+from .model import Comment
+from .model import DoubleQuotedString
+from .model import Float
+from .model import Identifier
+from .model import Infinity
+from .model import Integer
+from .model import JSONArray
+from .model import JSONObject
+from .model import JSONText
+from .model import NaN
+from .model import Node
+from .model import NullLiteral
+from .model import SingleQuotedString
+from .model import String
+from .model import UnaryOp
+from .parser import parse_source
 
 logger = logging.getLogger(__name__)
 # logger.setLevel(level=logging.DEBUG)

--- a/json5/loader.py
+++ b/json5/loader.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import typing
 from abc import abstractmethod
+from functools import singledispatchmethod
 from typing import Callable
 from typing import Literal
 
@@ -23,7 +24,6 @@ from json5.model import SingleQuotedString
 from json5.model import String
 from json5.model import UnaryOp
 from json5.parser import parse_source
-from json5.utils import singledispatchmethod
 
 logger = logging.getLogger(__name__)
 # logger.setLevel(level=logging.DEBUG)

--- a/json5/model.py
+++ b/json5/model.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import math
+import typing
+from collections import deque
 from typing import Any
 from typing import Literal
 
@@ -33,30 +35,109 @@ __all__ = [
 ]
 
 
-class Node:
-    excluded_names = ['excluded_names', 'wsc_before', 'wsc_after', 'leading_wsc']
+def walk(root: Node) -> typing.Generator[Node, None, None]:
+    todo = deque([root])
+    while todo:
+        node: Node = todo.popleft()
+        todo.extend(iter_child_nodes(node))
+        yield node
 
-    def __init__(self) -> None:
+
+def iter_child_nodes(node: Node) -> typing.Generator[Node, None, None]:
+    for attr, value in iter_fields(node):
+        if isinstance(value, Node):
+            yield value
+        elif isinstance(value, list):
+            for item in value:
+                if isinstance(item, Node):
+                    yield item
+
+
+def iter_fields(node: Node) -> typing.Generator[tuple[str, Any], None, None]:
+    for field_name in node._fields:
+        try:
+            value = getattr(node, field_name)
+            yield field_name, value
+        except AttributeError:
+            pass
+
+
+class Node:
+    excluded_names = ['excluded_names', 'wsc_before', 'wsc_after', 'leading_wsc', 'tok', 'end_tok']
+
+    def __init__(self, tok: JSON5Token | None = None, end_tok: JSON5Token | None = None):
         # Whitespace/Comments before/after the node
         self.wsc_before: list[str | Comment] = []
         self.wsc_after: list[str | Comment] = []
+        self._tok: JSON5Token | None = tok
+        self._end_tok: JSON5Token | None = end_tok
+
+    @property
+    def col_offset(self) -> int | None:
+        if self._tok is None:
+            return None
+        return self._tok.index
+
+    @property
+    def end_col_offset(self) -> int | None:
+        if self._end_tok is None:
+            return None
+
+        # TODO fix these cases in the tokenizer
+        if isinstance(self, (DoubleQuotedString, SingleQuotedString)):
+            if '\n' in self.raw_value:
+                return len(self.raw_value.rsplit('\n', 1)[-1])
+            else:
+                return self._end_tok.end
+        elif isinstance(self, BlockComment):
+            if '\n' in self.value:
+                return len(self.value.rsplit('\n', 1)[-1])
+            else:
+                return self._end_tok.end
+        return self._end_tok.end
+
+    @property
+    def lineno(self) -> int | None:
+        if self._tok is None:
+            return None
+        return self._tok.lineno
+
+    @property
+    def end_lineno(self) -> int | None:
+        if self._end_tok is None:
+            return None
+        r = self._end_tok.lineno
+        # TODO fix these cases in the tokenizer
+        if isinstance(self, (DoubleQuotedString, SingleQuotedString)):
+            return r + self.raw_value.count('\n')
+        elif isinstance(self, BlockComment):
+            return r + self.value.count('\n')
+        return r
 
     def __repr__(self) -> str:
         rep = (
             f"{self.__class__.__name__}("
             + ", ".join(
-                f"{key}={repr(value)}" for key, value in self.__dict__.items() if key not in self.excluded_names
+                f"{key}={repr(value)}"
+                for key, value in self.__dict__.items()
+                if not key.startswith('_') and key not in self.excluded_names
             )
             + ")"
         )
         return rep
 
+    @property
+    def _fields(self) -> list[str]:
+        fields = [item for item in list(self.__dict__) if not item.startswith('_') and item not in self.excluded_names]
+        fields.extend(['wsc_before', 'wsc_after'])
+        return fields
+
 
 class JSONText(Node):
-    def __init__(self, value: Value):
+    def __init__(self, value: Value, tok: JSON5Token | None = None, end_tok: JSON5Token | None = None):
         assert isinstance(value, Value)
         self.value: Value = value
-        super().__init__()
+        super().__init__(tok=tok, end_tok=tok)
 
 
 class Value(Node):
@@ -74,6 +155,7 @@ class JSONObject(Value):
         trailing_comma: TrailingComma | None = None,
         leading_wsc: list[str | Comment] | None = None,
         tok: JSON5Token | None = None,
+        end_tok: JSON5Token | None = None,
     ):
         kvps = list(key_value_pairs)
         for kvp in kvps:
@@ -82,8 +164,8 @@ class JSONObject(Value):
         self.key_value_pairs: list[KeyValuePair] = kvps
         self.trailing_comma: TrailingComma | None = trailing_comma
         self.leading_wsc: list[str | Comment] = leading_wsc or []
-        self.tok: JSON5Token | None = tok
-        super().__init__()
+
+        super().__init__(tok=tok, end_tok=end_tok)
 
 
 class JSONArray(Value):
@@ -93,6 +175,7 @@ class JSONArray(Value):
         trailing_comma: TrailingComma | None = None,
         leading_wsc: list[str | Comment] | None = None,
         tok: JSON5Token | None = None,
+        end_tok: JSON5Token | None = None,
     ):
         vals = list(values)
         for value in vals:
@@ -101,22 +184,24 @@ class JSONArray(Value):
         self.values: list[Value] = vals
         self.trailing_comma: TrailingComma | None = trailing_comma
         self.leading_wsc: list[str | Comment] = leading_wsc or []
-        self.tok: JSON5Token | None = tok
-        super().__init__()
+
+        super().__init__(tok=tok, end_tok=end_tok)
 
 
 class KeyValuePair(Node):
-    def __init__(self, key: Key, value: Value, tok: JSON5Token | None = None):
+    def __init__(self, key: Key, value: Value, tok: JSON5Token | None = None, end_tok: JSON5Token | None = None):
         assert isinstance(key, Key)
         assert isinstance(value, Value)
         self.key: Key = key
         self.value: Value = value
-        self.tok: JSON5Token | None = tok
-        super().__init__()
+
+        super().__init__(tok=tok, end_tok=end_tok)
 
 
 class Identifier(Key):
-    def __init__(self, name: str, raw_value: str | None = None, tok: JSON5Token | None = None):
+    def __init__(
+        self, name: str, raw_value: str | None = None, tok: JSON5Token | None = None, end_tok: JSON5Token | None = None
+    ):
         assert isinstance(name, str)
         if raw_value is None:
             raw_value = name
@@ -124,8 +209,8 @@ class Identifier(Key):
         assert len(name) > 0
         self.name: str = name
         self.raw_value: str = raw_value
-        self.tok: JSON5Token | None = tok
-        super().__init__()
+
+        super().__init__(tok=tok, end_tok=tok)
 
     def __hash__(self) -> int:
         return hash(self.name)
@@ -139,7 +224,14 @@ class Number(Value):
 
 
 class Integer(Number):
-    def __init__(self, raw_value: str, is_hex: bool = False, is_octal: bool = False, tok: JSON5Token | None = None):
+    def __init__(
+        self,
+        raw_value: str,
+        is_hex: bool = False,
+        is_octal: bool = False,
+        tok: JSON5Token | None = None,
+        end_tok: JSON5Token | None = None,
+    ):
         assert isinstance(raw_value, str)
         if is_hex and is_octal:
             raise ValueError("is_hex and is_octal are mutually exclusive")
@@ -156,26 +248,32 @@ class Integer(Number):
         self.raw_value: str = raw_value
         self.is_hex: bool = is_hex
         self.is_octal: bool = is_octal
-        self.tok: JSON5Token | None = tok
-        super().__init__()
+
+        super().__init__(tok=tok, end_tok=end_tok or tok)
 
 
 class Float(Number):
-    def __init__(self, raw_value: str, exp_notation: str | None = None, tok: JSON5Token | None = None):
+    def __init__(
+        self,
+        raw_value: str,
+        exp_notation: str | None = None,
+        tok: JSON5Token | None = None,
+        end_tok: JSON5Token | None = None,
+    ):
         value = float(raw_value)
         assert exp_notation is None or exp_notation in ('e', 'E')
         self.raw_value: str = raw_value
         self.exp_notation: str | None = exp_notation
-        self.tok: JSON5Token | None = tok
+
         self.value: float = value
-        super().__init__()
+        super().__init__(tok=tok, end_tok=end_tok or tok)
 
 
 class Infinity(Number):
-    def __init__(self, negative: bool = False, tok: JSON5Token | None = None):
+    def __init__(self, negative: bool = False, tok: JSON5Token | None = None, end_tok: JSON5Token | None = None):
         self.negative: bool = negative
-        self.tok: JSON5Token | None = tok
-        super().__init__()
+
+        super().__init__(tok=tok, end_tok=tok)
 
     @property
     def value(self) -> float:
@@ -190,9 +288,8 @@ class Infinity(Number):
 
 
 class NaN(Number):
-    def __init__(self, tok: JSON5Token | None = None):
-        self.tok: JSON5Token | None = tok
-        super().__init__()
+    def __init__(self, tok: JSON5Token | None = None, end_tok: JSON5Token | None = None):
+        super().__init__(tok=tok, end_tok=tok)
 
     @property
     def value(self) -> float:
@@ -208,63 +305,66 @@ class String(Value, Key):
 
 
 class DoubleQuotedString(String):
-    def __init__(self, characters: str, raw_value: str, tok: JSON5Token | None = None):
+    def __init__(
+        self, characters: str, raw_value: str, tok: JSON5Token | None = None, end_tok: JSON5Token | None = None
+    ):
         assert isinstance(raw_value, str)
         assert isinstance(characters, str)
         self.characters: str = characters
         self.raw_value: str = raw_value
-        self.tok: JSON5Token | None = tok
-        super().__init__()
+
+        super().__init__(tok=tok, end_tok=tok)
 
 
 class SingleQuotedString(String):
-    def __init__(self, characters: str, raw_value: str, tok: JSON5Token | None = None):
+    def __init__(
+        self, characters: str, raw_value: str, tok: JSON5Token | None = None, end_tok: JSON5Token | None = None
+    ):
         assert isinstance(raw_value, str)
         assert isinstance(characters, str)
         self.characters: str = characters
         self.raw_value: str = raw_value
-        self.tok: JSON5Token | None = tok
-        super().__init__()
+
+        super().__init__(tok=tok, end_tok=tok)
 
 
 class BooleanLiteral(Value):
-    def __init__(self, value: bool, tok: JSON5Token | None = None):
+    def __init__(self, value: bool, tok: JSON5Token | None = None, end_tok: JSON5Token | None = None):
         assert value in (True, False)
         self.value: bool = value
-        self.tok: JSON5Token | None = tok
-        super().__init__()
+
+        super().__init__(tok=tok, end_tok=tok)
 
 
 class NullLiteral(Value):
     value = None
 
-    def __init__(self, tok: JSON5Token | None = None):
-        self.tok: JSON5Token | None = None
-        super().__init__()
+    def __init__(self, tok: JSON5Token | None = None, end_tok: JSON5Token | None = None):
+        super().__init__(tok=tok, end_tok=tok)
 
 
 class UnaryOp(Value):
-    def __init__(self, op: Literal['-', '+'], value: Number, tok: JSON5Token | None = None):
+    def __init__(
+        self, op: Literal['-', '+'], value: Number, tok: JSON5Token | None = None, end_tok: JSON5Token | None = None
+    ):
         assert op in ('-', '+')
         assert isinstance(value, Number)
         self.op: Literal['-', '+'] = op
         self.value: Number = value
-        self.tok: JSON5Token | None = tok
-        super().__init__()
+
+        super().__init__(tok=tok, end_tok=end_tok)
 
 
 class TrailingComma(Node):
-    def __init__(self, tok: JSON5Token | None = None):
-        self.tok = tok
-        super().__init__()
+    def __init__(self, tok: JSON5Token | None = None, end_tok: JSON5Token | None = None):
+        super().__init__(tok=tok, end_tok=tok)  # Trailing comma is always a single COMMA token
 
 
 class Comment(Node):
-    def __init__(self, value: str, tok: JSON5Token | None = None):
+    def __init__(self, value: str, tok: JSON5Token | None = None, end_tok: JSON5Token | None = None):
         assert isinstance(value, str), f"Expected str got {type(value)}"
         self.value: str = value
-        self.tok: JSON5Token | None = tok
-        super().__init__()
+        super().__init__(tok=tok, end_tok=tok)  # Comments are always a single token
 
 
 class LineComment(Comment):

--- a/json5/model.py
+++ b/json5/model.py
@@ -108,7 +108,7 @@ class Node:
         #     return r + self.value.count('\n')
         return r
 
-    def __str__(self) -> str:
+    def __repr__(self) -> str:
         rep = (
             f"{self.__class__.__name__}("
             + ", ".join(

--- a/json5/parser.py
+++ b/json5/parser.py
@@ -12,11 +12,28 @@ import regex as re
 from sly import Parser  # type: ignore
 from sly.yacc import SlyLogger  # type: ignore
 
-from json5.model import *
-from json5.tokenizer import JSON5Token
-from json5.tokenizer import JSONLexer
-from json5.tokenizer import tokenize
-from json5.utils import JSON5DecodeError
+from .model import BlockComment
+from .model import BooleanLiteral
+from .model import Comment
+from .model import DoubleQuotedString
+from .model import Float
+from .model import Identifier
+from .model import Infinity
+from .model import Integer
+from .model import JSONArray
+from .model import JSONObject
+from .model import JSONText
+from .model import KeyValuePair
+from .model import LineComment
+from .model import NaN
+from .model import NullLiteral
+from .model import SingleQuotedString
+from .model import TrailingComma
+from .model import UnaryOp
+from .tokenizer import JSON5Token
+from .tokenizer import JSONLexer
+from .tokenizer import tokenize
+from .utils import JSON5DecodeError
 
 
 class QuietSlyLogger(SlyLogger):  # type: ignore[misc]

--- a/json5/parser.py
+++ b/json5/parser.py
@@ -266,7 +266,7 @@ class JSONParser(Parser):  # type: ignore[misc]
             value.wsc_before.append(wsc)
         for wsc in p.wsc2:
             value.wsc_after.append(wsc)
-        return KeyValuePair(key=p.key, value=p.value, tok=key._tok, end_tok=value._end_tok)
+        return KeyValuePair(key=p.key, value=p.value)
 
     @_('object_delimiter_seen COMMA { wsc } [ first_key_value_pair ]')
     def subsequent_key_value_pair(self, p: SubsequentKeyValuePairProduction) -> KeyValuePair | TrailingComma:
@@ -340,14 +340,14 @@ class JSONParser(Parser):  # type: ignore[misc]
     @_('seen_LBRACE LBRACE { wsc } [ key_value_pairs ] seen_RBRACE RBRACE')
     def json_object(self, p: T_JsonObjectProduction) -> JSONObject:
         if not p.key_value_pairs:
-            node = JSONObject(leading_wsc=list(p.wsc or []), tok=p._slice[0], end_tok=p._slice[5])
+            node = JSONObject(leading_wsc=list(p.wsc or []), tok=p._slice[1], end_tok=p._slice[5])
         else:
             kvps, trailing_comma = p.key_value_pairs
             node = JSONObject(
                 *kvps,
                 trailing_comma=trailing_comma,
                 leading_wsc=list(p.wsc or []),
-                tok=p._slice[0],
+                tok=p._slice[1],
                 end_tok=p._slice[5],
             )
 

--- a/json5/parser.py
+++ b/json5/parser.py
@@ -23,6 +23,7 @@ from .model import Integer
 from .model import JSONArray
 from .model import JSONObject
 from .model import JSONText
+from .model import Key
 from .model import KeyValuePair
 from .model import LineComment
 from .model import NaN
@@ -30,6 +31,7 @@ from .model import NullLiteral
 from .model import SingleQuotedString
 from .model import TrailingComma
 from .model import UnaryOp
+from .model import Value
 from .tokenizer import JSON5Token
 from .tokenizer import JSONLexer
 from .tokenizer import tokenize

--- a/json5/tokenizer.py
+++ b/json5/tokenizer.py
@@ -22,14 +22,20 @@ class JSON5Token(Token):  # type: ignore[misc]
     '''
 
     def __init__(self, tok: Token, doc: str):
-        self.type = tok.type
-        self.value = tok.value
-        self.lineno = tok.lineno
-        self.index = tok.index
-        self.doc = doc
-        self.end = getattr(tok, 'end', None)
+        self.type: str | None = tok.type
+        self.value: str = tok.value
+        self.lineno: int = tok.lineno
+        self.index: int = tok.index
+        self.doc: str = doc
+        self.end: int = tok.end
 
     __slots__ = ('type', 'value', 'lineno', 'index', 'doc', 'end')
+
+    def __str__(self) -> str:
+        if self.value:
+            return self.value
+        else:
+            return ''
 
     def __repr__(self) -> str:
         return f'JSON5Token(type={self.type!r}, value={self.value!r}, lineno={self.lineno}, index={self.index}, end={self.end})'
@@ -125,3 +131,9 @@ def tokenize(text: str) -> Generator[JSON5Token, None, None]:
     lexer = JSONLexer()
     tokens = lexer.tokenize(text)
     return tokens
+
+
+def reversed_enumerate(tokens: typing.Sequence[JSON5Token]) -> typing.Generator[tuple[int, JSON5Token], None, None]:
+    for i in reversed(range(len(tokens))):
+        tok = tokens[i]
+        yield i, tok

--- a/json5/tokenizer.py
+++ b/json5/tokenizer.py
@@ -29,6 +29,19 @@ class JSON5Token(Token):  # type: ignore[misc]
         self.doc: str = doc
         self.end: int = tok.end
 
+    @property
+    def colno(self) -> int:
+        line_start_index = self.doc.rfind('\n', 0, self.index) + 1
+        return self.index - line_start_index
+
+    @property
+    def end_colno(self) -> int:
+        return self.colno + self.end - self.index
+
+    @property
+    def end_lineno(self) -> int:
+        return self.lineno + self.value.count('\n')
+
     __slots__ = ('type', 'value', 'lineno', 'index', 'doc', 'end')
 
     def __str__(self) -> str:
@@ -90,8 +103,15 @@ class JSONLexer(Lexer):  # type: ignore[misc]
     COLON = r"\:"
     COMMA = r"\,"
 
-    DOUBLE_QUOTE_STRING = r'"(?:[^"\\]|\\.)*"'
-    SINGLE_QUOTE_STRING = r"'(?:[^'\\]|\\.)*'"
+    @_(r'"(?:[^"\\]|\\.)*"')
+    def DOUBLE_QUOTE_STRING(self, tok: JSON5Token) -> JSON5Token:
+        self.lineno += tok.value.count('\n')
+        return tok
+
+    @_(r"'(?:[^'\\]|\\.)*'")
+    def SINGLE_QUOTE_STRING(self, tok: JSON5Token) -> JSON5Token:
+        self.lineno += tok.value.count('\n')
+        return tok
 
     LINE_COMMENT = r"//[^\n]*"
 

--- a/json5/tokenizer.py
+++ b/json5/tokenizer.py
@@ -9,7 +9,7 @@ import regex as re
 from sly import Lexer  # type: ignore
 from sly.lex import Token  # type: ignore
 
-from json5.utils import JSON5DecodeError
+from .utils import JSON5DecodeError
 
 logger = logging.getLogger(__name__)
 # logger.addHandler(logging.StreamHandler(stream=sys.stderr))

--- a/json5/utils.py
+++ b/json5/utils.py
@@ -1,28 +1,9 @@
 from __future__ import annotations
 
 import typing
-from functools import singledispatch
-from functools import update_wrapper
 from json import JSONDecodeError
-from typing import Any
-from typing import Callable
 
-try:
-    from functools import singledispatchmethod
-except ImportError:
-
-    def singledispatchmethod(func: Callable[..., Any]) -> Any:  # type: ignore[no-redef]
-        dispatcher = singledispatch(func)
-
-        def wrapper(*args: Any, **kwargs: Any) -> Any:
-            return dispatcher.dispatch(args[1].__class__)(*args, **kwargs)
-
-        wrapper.register = dispatcher.register  # type: ignore[attr-defined]
-        update_wrapper(wrapper, func)
-        return wrapper
-
-
-__all__ = ['singledispatchmethod', 'JSON5DecodeError']
+__all__ = ['JSON5DecodeError']
 
 if typing.TYPE_CHECKING:
     from .tokenizer import JSON5Token

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-sly
+sly>=0.5
 regex
 pytest
 mypy

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ license_files = LICENSE
 packages = json5
 python_requires = >=3.8.0
 install_requires =
-    sly
+    sly>=0.5
     regex
 
 [options.package_data]

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,47 @@
+import ast
+
+import pytest
+
+import json5.loader
+import json5.model
+
+TEST_TEXT = '''\
+{
+    "string_on_same_line":     "string on same line",
+          "multiline_dq_string": "this line has a \
+continuation",  
+      "leadingDecimalPoint": .8675309  ,    
+      "andTrailing":     8675309.,  
+    "trailingComma": 'in objects',   
+        "backwardsCompatible": "with JSON",
+}
+'''
+
+model = json5.loads(TEST_TEXT, loader=json5.loader.ModelLoader())
+tree = ast.parse(TEST_TEXT)
+ast_nodes = [
+    node for node in list(ast.walk(tree)) if not isinstance(node, (ast.Expr, ast.Load, ast.Module, ast.UnaryOp))
+]
+json5_nodes = [
+    node
+    for node in list(json5.model.walk(model))
+    if not isinstance(node, (json5.model.TrailingComma, json5.model.JSONText))
+]
+
+assert len(ast_nodes) == len(json5_nodes)
+
+
+@pytest.mark.parametrize('ast_node, json5_node', list(zip(ast_nodes, json5_nodes)))
+@pytest.mark.parametrize(
+    'attr_name',
+    [
+        'col_offset',
+        'end_col_offset',
+        'lineno',
+        'end_lineno',
+    ],
+)
+def test_node_attribute_accuracy(attr_name: str, ast_node, json5_node):
+    assert getattr(json5_node, attr_name) == getattr(
+        ast_node, attr_name
+    ), f'{attr_name} did not match {ast_node!r}, {json5_node!r}'


### PR DESCRIPTION
Adds new properties to `JSON5Token` to handle tokens that span multiple lines:
- `colno` -- the index at which the token starts, relative to the line on which the token starts
- `end_colno` the index at which the token ends, relative to the line on which the token ends
- `end_lineno` - the line number in the document in which the token ends


Restructures `JSONObject` to store keys and values separately in `.keys` and `.values` attributes seprately. This change also removes `KeyValuePair` as a Node object. Instead, the underlying data model will store a list of keys and list of values in separate attributes. A new attribute for `JSONObject`, `key_value_pairs`, which will be a named tuple (`typing.NamedTuple`) that
provides the `key` and `value` attributes, so the interface remains mostly the same.

This change brings more congruity with how the stdlib `ast` module handles Python dictionaries, to which
Python users may be more accustomed. It also maintains, by interface, the same structure for [JSON5 members](https://spec.json5.org/#prod-JSON5MemberList) with the new `key_value_pairs` property (although it itself is not a Node).